### PR TITLE
WEB-3319: Fixing author relationships

### DIFF
--- a/app/lib/parser/chapter_metadata.rb
+++ b/app/lib/parser/chapter_metadata.rb
@@ -16,7 +16,7 @@ module Parser
 
     def apply!
       chapter.assign_attributes(simple_attributes)
-      chapter.authors << authors if authors.present?
+      chapter.authors += authors if authors.present?
     end
 
     def authors

--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -27,7 +27,7 @@ module Parser
     def update_authors_on_chapters
       book.sections.each do |section|
         section.chapters.each do |chapter|
-          chapter.authors << authors
+          chapter.authors += authors
         end
       end
     end


### PR DESCRIPTION
Using `<<` instead of `+=` meant we had many nested levels of arrays.
This now should have a perfectly flat lovely array of authors.

This is (currently) the most recently uploaded payload to alexandria.