### PR TITLE
WEB-3337: <h1> Tags are now ignored

### DIFF
--- a/app/lib/renderer/rw_markdown_renderer.rb
+++ b/app/lib/renderer/rw_markdown_renderer.rb
@@ -17,6 +17,12 @@ module Renderer
       @root_path = attributes[:root_path]
     end
 
+    def header(text, header_level)
+      return nil if header_level == 1
+
+      "<h#{header_level}>#{text}</h#{header_level}>"
+    end
+
     def image(link, title, alt_text)
       return %(<img src="#{link}" alt="#{alt_text}" title="#{title}" />) if image_provider.blank?
 


### PR DESCRIPTION
I have a feeling that this will also remove the TOC anchors, but I'm
pretty sure that we weren't using them anyway.