### PR TITLE
WEB-3251: Adding support for a materials_url read from the metadata

### DIFF
--- a/app/lib/linting/metadata/publish_attributes.rb
+++ b/app/lib/linting/metadata/publish_attributes.rb
@@ -4,7 +4,7 @@ module Linting
   module Metadata
     # Check for the required attributes in the publish.yaml file
     class PublishAttributes
-      REQUIRED_ATTRIBUTES = %i[sku edition title description released_at authors segments].freeze
+      REQUIRED_ATTRIBUTES = %i[sku edition title description released_at authors segments materials_url].freeze
 
       attr_reader :file, :attributes
 

--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -5,7 +5,7 @@ module Parser
   class Publish
     include Util::PathExtraction
 
-    VALID_BOOK_ATTRIBUTES = %i[sku edition title description released_at].freeze
+    VALID_BOOK_ATTRIBUTES = %i[sku edition title description released_at materials_url].freeze
 
     attr_reader :book
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -5,7 +5,7 @@ class Book
   include ActiveModel::Model
   include ActiveModel::Serializers::JSON
 
-  attr_accessor :sku, :edition, :title, :description, :released_at, :sections, :git_commit_hash
+  attr_accessor :sku, :edition, :title, :description, :released_at, :sections, :git_commit_hash, :materials_url
   validates :sku, :edition, :title, presence: true
 
   def initialize(attributes = {})
@@ -15,6 +15,6 @@ class Book
 
   # Used for serialisation
   def attributes
-    { sku: nil, edition: nil, title: nil, description: nil, released_at: nil, sections: [], git_commit_hash: nil }.stringify_keys
+    { sku: nil, edition: nil, title: nil, description: nil, released_at: nil, sections: [], git_commit_hash: nil, materials_url: nil }.stringify_keys
   end
 end


### PR DESCRIPTION
This is now a required attribute in publish.yaml. It will be sent to
alexandria as materials_url.