### PR TITLE
WEB-3417: Adding new fields to robles metadata

### DIFF
--- a/app/lib/image_provider/extractor.rb
+++ b/app/lib/image_provider/extractor.rb
@@ -20,14 +20,14 @@ module ImageProvider
       MarkdownImageExtractor.images_from(file)
     end
 
-    def image_paths
+    def image_paths # rubocop:disable Metrics/AbcSize
       book.sections.map do |section|
         from_chapters = section.chapters.map do |chapter|
-          extract_images_from_markdown(chapter.markdown_file)
+          extract_images_from_markdown(chapter.markdown_file) + chapter.image_attachment_paths
         end
 
-        from_chapters + extract_images_from_markdown(section.markdown_file)
-      end.flatten.compact.uniq
+        from_chapters + extract_images_from_markdown(section.markdown_file) + section.image_attachment_paths
+      end.flatten.compact.uniq + book.image_attachment_paths
     end
   end
 end

--- a/app/lib/linting/image/attachable.rb
+++ b/app/lib/linting/image/attachable.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Linting
+  module Image
+    # Find the images in a markdown file and lint them
+    module Attachable
+      include Linting::FileExistenceChecker
+
+      attr_reader :object
+
+      def initialize(object)
+        @object = object
+      end
+
+      def lint_attachments
+        non_existent_images.flat_map do |image|
+          locate_errors(image[:relative_path]).map do |location|
+            annotation(image, location)
+          end
+        end
+      end
+
+      def locate_errors(image)
+        [{
+          start_line: 1,
+          end_line: 1
+        }]
+      end
+
+      def message_for_image(image)
+        return 'This file does not exist.' unless file_exists?(image[:absolute_path], case_insensitive: true)
+
+        'This file does not exist. Check for case sensitivity—a very similarly named file does exist, but has different case.'
+      end
+
+      def annotation(image, location)
+        Linting::Annotation.new(
+          location.merge(
+            absolute_path: '/data/src/publish.yaml', # WARNING: This is hardcoded and should probably be re-done
+            annotation_level: 'failure',
+            message: message_for_image(image),
+            title: 'Invalid image reference'
+          )
+        )
+      end
+
+      def non_existent_images
+        @non_existent_images ||= object.image_attachment_paths.reject do |image|
+          file_exists?(image[:absolute_path], case_insensitive: false)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/linting/image/book.rb
+++ b/app/lib/linting/image/book.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Linting
+  module Image
+    # Lint the image associated with a book
+    class Book
+      include Linting::Image::Attachable
+
+      def self.lint(book)
+        new(book).lint
+      end
+
+      def lint
+        [].tap do |annotations|
+          annotations.concat(lint_attachments)
+          object.sections.each do |section|
+            annotations.concat(Linting::Image::Section.lint(section))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/linting/image/chapter.rb
+++ b/app/lib/linting/image/chapter.rb
@@ -4,21 +4,20 @@ module Linting
   module Image
     # Lint the images associated with a chapter
     class Chapter
+      include Linting::Image::Attachable
       include Linting::Image::Markdown
 
-      attr_reader :chapter
-      delegate :markdown_file, to: :chapter
+      delegate :markdown_file, to: :object
 
       def self.lint(chapter)
-        new(chapter: chapter).lint
-      end
-
-      def initialize(chapter:)
-        @chapter = chapter
+        new(chapter).lint
       end
 
       def lint
-        lint_markdown_images
+        [].tap do |annotations|
+          annotations.concat(lint_attachments)
+          annotations.concat(lint_markdown_images)
+        end
       end
     end
   end

--- a/app/lib/linting/image/section.rb
+++ b/app/lib/linting/image/section.rb
@@ -4,23 +4,20 @@ module Linting
   module Image
     # Lint the image associated with a section
     class Section
+      include Linting::Image::Attachable
       include Linting::Image::Markdown
 
-      attr_reader :section
-      delegate :markdown_file, to: :section
+      delegate :markdown_file, to: :object
 
       def self.lint(section)
-        new(section: section).lint
-      end
-
-      def initialize(section:)
-        @section = section
+        new(section).lint
       end
 
       def lint
         [].tap do |annotations|
+          annotations.concat(lint_attachments)
           annotations.concat(lint_markdown_images)
-          section.chapters.each do |chapter|
+          object.chapters.each do |chapter|
             annotations.concat(Linting::Image::Chapter.lint(chapter))
           end
         end

--- a/app/lib/linting/image_linter.rb
+++ b/app/lib/linting/image_linter.rb
@@ -10,11 +10,7 @@ module Linting
     end
 
     def lint
-      [].tap do |annotations|
-        book.sections.each do |section|
-          annotations.concat(Linting::Image::Section.lint(section))
-        end
-      end
+      Linting::Image::Book.lint(book)
     end
   end
 end

--- a/app/lib/linting/metadata/publish_attributes.rb
+++ b/app/lib/linting/metadata/publish_attributes.rb
@@ -4,7 +4,8 @@ module Linting
   module Metadata
     # Check for the required attributes in the publish.yaml file
     class PublishAttributes
-      REQUIRED_ATTRIBUTES = %i[sku edition title description released_at authors segments materials_url].freeze
+      REQUIRED_ATTRIBUTES = %i[sku edition title description released_at authors segments materials_url
+                               cover_image version_description difficulty platform language editor].freeze
 
       attr_reader :file, :attributes
 

--- a/app/lib/parser/book_segments.rb
+++ b/app/lib/parser/book_segments.rb
@@ -18,7 +18,8 @@ module Parser
       raise 'Invalid segment kind' unless section_segment[:kind] == 'section'
 
       chapters = segments.map.with_index { |segment, idx| parse_chapter(segment, idx) }
-      Section.new(markdown_file: apply_path(section_segment[:path]), ordinal: index, chapters: chapters).tap do |section|
+      markdown_file = apply_path(section_segment[:path])
+      Section.new(markdown_file: markdown_file, ordinal: index, chapters: chapters, root_path: Pathname.new(markdown_file).dirname.to_s).tap do |section|
         SectionMetadata.new(section).apply!
       end
     end
@@ -26,7 +27,8 @@ module Parser
     def parse_chapter(segment, index)
       raise 'Invalid semgent kind' unless segment[:kind] == 'chapter'
 
-      Chapter.new(markdown_file: apply_path(segment[:path]), ordinal: index).tap do |chapter|
+      markdown_file = apply_path(segment[:path])
+      Chapter.new(markdown_file: markdown_file, ordinal: index, root_path: Pathname.new(markdown_file).dirname.to_s).tap do |chapter|
         ChapterMetadata.new(chapter).apply!
       end
     end

--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -24,6 +24,7 @@ module Parser
 
     def apply_additonal_metadata
       book.assign_attributes(additional_attributes)
+      book.root_path = root_directory
     end
 
     def update_authors_on_chapters

--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -5,7 +5,9 @@ module Parser
   class Publish
     include Util::PathExtraction
 
-    VALID_BOOK_ATTRIBUTES = %i[sku edition title description released_at materials_url].freeze
+    VALID_BOOK_ATTRIBUTES = %i[sku edition title description released_at materials_url
+                               cover_image version_description professional difficulty platform
+                               language editor who_is_this_for_md covered_concepts_md].freeze
 
     attr_reader :book
 

--- a/app/lib/renderer/book.rb
+++ b/app/lib/renderer/book.rb
@@ -3,11 +3,13 @@
 module Renderer
   # Takes a sparse Book object (i.e. parsed) and renders the markdown
   class Book
+    include ImageAttachable
     include MarkdownRenderable
     include Util::Logging
 
     def render
       logger.info 'Beginning book render'
+      attach_images
       render_markdown
       object.sections.each do |section|
         section_renderer = Renderer::Section.new(section, image_provider: image_provider)

--- a/app/lib/renderer/book.rb
+++ b/app/lib/renderer/book.rb
@@ -3,19 +3,13 @@
 module Renderer
   # Takes a sparse Book object (i.e. parsed) and renders the markdown
   class Book
+    include MarkdownRenderable
     include Util::Logging
-
-    attr_reader :book
-    attr_reader :image_provider
-
-    def initialize(book:, image_provider: nil)
-      @book = book
-      @image_provider = image_provider
-    end
 
     def render
       logger.info 'Beginning book render'
-      book.sections.each do |section|
+      render_markdown
+      object.sections.each do |section|
         section_renderer = Renderer::Section.new(section, image_provider: image_provider)
         section_renderer.render
       end

--- a/app/lib/renderer/chapter.rb
+++ b/app/lib/renderer/chapter.rb
@@ -3,11 +3,13 @@
 module Renderer
   # Takes a Chapter model, and updates it with the markdown rendered into HTML
   class Chapter
+    include ImageAttachable
     include MarkdownRenderable
     include Util::Logging
 
     def render
       logger.info "Beginning chapter render: #{object.title}"
+      attach_images
       render_markdown
     end
   end

--- a/app/lib/renderer/image_attachable.rb
+++ b/app/lib/renderer/image_attachable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Renderer
+  # Methods that make it possible to attach images to objects
+  module ImageAttachable
+    # This object should include Concerns::MarkdownRenderable
+    attr_reader :object, :image_provider
+
+    def initialize(object, image_provider:)
+      @object = object
+      @image_provider = image_provider
+    end
+
+    def attach_images
+      return if image_provider.blank?
+
+      object.image_attachment_loop do |local_url|
+        representations = image_provider.representations_for_local_url(local_url)
+        representations.find { |r| r.width == :original }.remote_url
+      end
+    end
+  end
+end

--- a/app/lib/renderer/markdown_file_renderer.rb
+++ b/app/lib/renderer/markdown_file_renderer.rb
@@ -2,7 +2,7 @@
 
 module Renderer
   # Read a file and render the markdown
-  class Markdown
+  class MarkdownFileRenderer
     include Util::Logging
 
     attr_reader :path
@@ -14,7 +14,7 @@ module Renderer
     end
 
     def render
-      logger.debug 'Markdown::render'
+      logger.debug 'MarkdownFileRenderer::render'
       redcarpet.render(raw_content)
     end
 

--- a/app/lib/renderer/markdown_renderable.rb
+++ b/app/lib/renderer/markdown_renderable.rb
@@ -12,11 +12,17 @@ module Renderer
     end
 
     def render_markdown
-      object.markdown_attribute = md_renderer.render
+      object.markdown_render_loop do |content, file|
+        file ? render_file(content) : render_string(content)
+      end
     end
 
-    def md_renderer
-      @md_renderer ||= Markdown.new(path: object.markdown_file, image_provider: image_provider)
+    def render_file(filename)
+      MarkdownFileRenderer.new(path: filename, image_provider: image_provider).render
+    end
+
+    def render_string(content)
+      MarkdownStringRenderer.new(content: content).render
     end
   end
 end

--- a/app/lib/renderer/markdown_string_renderer.rb
+++ b/app/lib/renderer/markdown_string_renderer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Renderer
+  # Render a string as markdown
+  class MarkdownStringRenderer
+    include Util::Logging
+
+    attr_reader :content
+
+    def initialize(content:)
+      @content = content
+    end
+
+    def render
+      logger.debug 'MarkdownStringRenderer::render'
+      redcarpet.render(content)
+    end
+
+    def redcarpet_renderer
+      @redcarpet_renderer ||= RWMarkdownRenderer.new(with_toc_data: true)
+    end
+
+    def redcarpet
+      @redcarpet ||= Redcarpet::Markdown.new(redcarpet_renderer,
+                                             fenced_code_blocks: true,
+                                             disable_indented_code_blocks: true,
+                                             autolink: true,
+                                             strikethrough: true,
+                                             tables: true,
+                                             hightlight: true)
+    end
+  end
+end

--- a/app/lib/renderer/section.rb
+++ b/app/lib/renderer/section.rb
@@ -3,11 +3,13 @@
 module Renderer
   # Takes a Section model, and updates it with the markdown (of the chapters) rendered into HTML
   class Section
+    include ImageAttachable
     include MarkdownRenderable
     include Util::Logging
 
     def render
       logger.info "Beginning section render: #{object.title}"
+      attach_images
       render_markdown
       object.chapters.each do |chapter|
         chapter_renderer = Renderer::Chapter.new(chapter, image_provider: image_provider)

--- a/app/lib/runner/base.rb
+++ b/app/lib/runner/base.rb
@@ -19,7 +19,7 @@ module Runner
       book = parser.parse
       image_provider = local ? nil : ImageProvider::Provider.new(book: book)
       image_provider&.process
-      renderer = Renderer::Book.new(book: book, image_provider: image_provider)
+      renderer = Renderer::Book.new(book, image_provider: image_provider)
       renderer.render
       book
     end
@@ -30,7 +30,7 @@ module Runner
       book = parser.parse
       image_provider = ImageProvider::Provider.new(book: book)
       image_provider.process
-      Renderer::Book.new(book: book, image_provider: image_provider).render
+      Renderer::Book.new(book, image_provider: image_provider).render
       Api::Alexandria::BookUploader.upload(book)
       notify_success(book: book)
     rescue StandardError => e

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,13 +4,16 @@
 class Book
   include ActiveModel::Model
   include ActiveModel::Serializers::JSON
+  include Concerns::ImageAttachable
   include Concerns::MarkdownRenderable
 
   attr_accessor :sku, :edition, :title, :description, :released_at, :sections, :git_commit_hash,
                 :materials_url, :cover_image, :version_description, :professional, :difficulty,
-                :platform, :language, :editor, :who_is_this_for_md, :covered_concepts_md
+                :platform, :language, :editor, :who_is_this_for_md, :covered_concepts_md, :root_path
+  attr_image :cover_image_url, source: :cover_image
   attr_markdown :who_is_this_for, source: :who_is_this_for_md, file: false
   attr_markdown :covered_concepts, source: :covered_concepts_md, file: false
+
   validates :sku, :edition, :title, presence: true
   validates_inclusion_of :difficulty, in: %w[beginner intermediate advanced]
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,9 +4,15 @@
 class Book
   include ActiveModel::Model
   include ActiveModel::Serializers::JSON
+  include Concerns::MarkdownRenderable
 
-  attr_accessor :sku, :edition, :title, :description, :released_at, :sections, :git_commit_hash, :materials_url
+  attr_accessor :sku, :edition, :title, :description, :released_at, :sections, :git_commit_hash,
+                :materials_url, :cover_image, :version_description, :professional, :difficulty,
+                :platform, :language, :editor, :who_is_this_for_md, :covered_concepts_md
+  attr_markdown :who_is_this_for, source: :who_is_this_for_md, file: false
+  attr_markdown :covered_concepts, source: :covered_concepts_md, file: false
   validates :sku, :edition, :title, presence: true
+  validates_inclusion_of :difficulty, in: %w[beginner intermediate advanced]
 
   def initialize(attributes = {})
     super
@@ -15,6 +21,9 @@ class Book
 
   # Used for serialisation
   def attributes
-    { sku: nil, edition: nil, title: nil, description: nil, released_at: nil, sections: [], git_commit_hash: nil, materials_url: nil }.stringify_keys
+    { sku: nil, edition: nil, title: nil, description: nil, released_at: nil, sections: [],
+      git_commit_hash: nil, materials_url: nil, cover_image_url: nil, version_description: nil,
+      professional: nil, difficulty: nil, platform: nil, language: nil, editor: nil,
+      who_is_this_for: nil, covered_concepts: nil }.stringify_keys
   end
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -8,7 +8,7 @@ class Chapter
   include Concerns::TitleCleanser
 
   attr_accessor :title, :number, :ordinal, :description, :body, :authors, :markdown_file
-  attr_markdown :body
+  attr_markdown :body, source: :markdown_file, file: true
   validates :title, :number, :ordinal, :markdown_file, presence: true
 
   def initialize(attributes = {})

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -7,7 +7,7 @@ class Chapter
   include Concerns::MarkdownRenderable
   include Concerns::TitleCleanser
 
-  attr_accessor :title, :number, :ordinal, :description, :body, :authors, :markdown_file
+  attr_accessor :title, :number, :ordinal, :description, :authors, :markdown_file
   attr_markdown :body, source: :markdown_file, file: true
   validates :title, :number, :ordinal, :markdown_file, presence: true
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -4,10 +4,11 @@
 class Chapter
   include ActiveModel::Model
   include ActiveModel::Serializers::JSON
+  include Concerns::ImageAttachable
   include Concerns::MarkdownRenderable
   include Concerns::TitleCleanser
 
-  attr_accessor :title, :number, :ordinal, :description, :authors, :markdown_file
+  attr_accessor :title, :number, :ordinal, :description, :authors, :markdown_file, :root_path
   attr_markdown :body, source: :markdown_file, file: true
   validates :title, :number, :ordinal, :markdown_file, presence: true
 

--- a/app/models/concerns/image_attachable.rb
+++ b/app/models/concerns/image_attachable.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Concerns
+  # Adds a method to allow attributes to be marked as containing an image
+  module ImageAttachable
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :_image_attachable_attributes, instance_writer: false, default: []
+    end
+
+    class_methods do
+      # Specify the name of the attribute that the CDN image URL should be stored in
+      def attr_image(attribute, source:)
+        _image_attachable_attributes.push({ destination: attribute, source: source })
+        attr_accessor attribute
+      end
+    end
+
+    # Local paths
+    def image_attachment_paths
+      _image_attachable_attributes.map do |attr|
+        path = send(attr[:source])
+        {
+          relative_path: path,
+          absolute_path: (Pathname.new(root_path) + path).to_s
+        }
+      end
+    end
+
+    # Allows looping through the image attachment attributes, populating their remote URLs
+    # Takes a block with one argument--the local URL of the file
+    def image_attachment_loop(&block)
+      _image_attachable_attributes.each do |attribute|
+        local_url = (Pathname.new(root_path) + send(attribute[:source])).to_s
+        remote_url = block.call(local_url)
+        send("#{attribute[:destination]}=".to_sym, remote_url)
+      end
+    end
+  end
+end

--- a/app/models/concerns/markdown_renderable.rb
+++ b/app/models/concerns/markdown_renderable.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Concerns
-  # Adds a method that denotes which attribute should be populated with markdown
-  # Use in conjunction with Renderer::MarkdownRenderable
+  # Adds methods to allow attributes to be marked as containing markdown
   module MarkdownRenderable
     extend ActiveSupport::Concern
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -7,7 +7,7 @@ class Section
   include Concerns::MarkdownRenderable
   include Concerns::TitleCleanser
 
-  attr_accessor :title, :number, :ordinal, :description, :chapters, :markdown_file
+  attr_accessor :title, :number, :ordinal, :chapters, :markdown_file
   attr_markdown :description, source: :markdown_file, file: true
   validates :title, :number, :ordinal, presence: true
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -8,7 +8,7 @@ class Section
   include Concerns::TitleCleanser
 
   attr_accessor :title, :number, :ordinal, :description, :chapters, :markdown_file
-  attr_markdown :description
+  attr_markdown :description, source: :markdown_file, file: true
   validates :title, :number, :ordinal, presence: true
 
   def initialize(attributes = {})

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -4,10 +4,11 @@
 class Section
   include ActiveModel::Model
   include ActiveModel::Serializers::JSON
+  include Concerns::ImageAttachable
   include Concerns::MarkdownRenderable
   include Concerns::TitleCleanser
 
-  attr_accessor :title, :number, :ordinal, :chapters, :markdown_file
+  attr_accessor :title, :number, :ordinal, :chapters, :markdown_file, :root_path
   attr_markdown :description, source: :markdown_file, file: true
   validates :title, :number, :ordinal, presence: true
 


### PR DESCRIPTION
This adds the following fields:

```
    "cover_image_url": "<string (full url)>",
    "version_description": "<string (ex. 'Eighth Edition')>",
    "professional": "<boolean>",
    "difficulty": "<string (beginner/intermediate/advanced)>",
    "platform": "<string>",
    "language": "<string>",
    "editor": "<string>",
    "who_is_this_for": "<string with HTML>",
    "covered_concepts": "<string with HTML>"
```

In order to support this, the renderer has been extended to allow individual attributes to be marked as containing markdown, in addition to them containing a path to a markdown file. It's also now possible to have more than one of these attributes on a model object.

Model objects can now also have image attributes, which will be uploaded to the CDN in the same way. currently we only vend the original image size to the API, but I'd suggest that we might want to send all image representations somehow?

Linting has also been updated to support these new attachable images. This isn't perfect, but some refactoring needs to take place to better support the linting.