### PR TITLE
WEB-3425: Normalise image paths

### DIFF
--- a/app/lib/image_provider/markdown_image_extractor.rb
+++ b/app/lib/image_provider/markdown_image_extractor.rb
@@ -31,7 +31,11 @@ module ImageProvider
     def images
       md_renderer.reset
       renderer.render(markdown)
-      md_renderer.images.map { |path| { relative_path: path, absolute_path: apply_path(path) } }
+      md_renderer.images.map { |path| { relative_path: cleanpath(path), absolute_path: cleanpath(apply_path(path)) } }
+    end
+
+    def cleanpath(path)
+      Pathname.new(path).cleanpath.to_s
     end
 
     def renderer

--- a/app/lib/image_provider/provider.rb
+++ b/app/lib/image_provider/provider.rb
@@ -25,8 +25,9 @@ module ImageProvider
     end
 
     def representations_for_local_url(url)
+      clean_url = Pathname.new(url).cleanpath.to_s
       extractor.images
-               .find { |image| image.local_url == url }
+               .find { |image| image.local_url == clean_url }
                &.representations
     end
 


### PR DESCRIPTION
./images/image.png is now interpreted the same as images/image.png