### PR TITLE
WEB-3513: Parsing errors in chapter metadata are now labelled

### DIFF
--- a/app/lib/parser/error.rb
+++ b/app/lib/parser/error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Parser
+  # An error for capturing parsing issues
+  class Error < StandardError
+    attr_reader :file
+
+    def initialize(file:, error: nil, msg: nil)
+      message = "There was a problem parsing #{file}"
+      message += "\n#{error.class.name}\n#{error.message}" if error.present?
+      message += "\n#{msg}" if msg.present?
+
+      super(message)
+      @file = file
+    end
+  end
+end

--- a/app/lib/parser/markdown_metadata.rb
+++ b/app/lib/parser/markdown_metadata.rb
@@ -12,7 +12,13 @@ module Parser
     end
 
     def metadata
-      @metadata ||= Psych.load(extract_metadata).deep_symbolize_keys
+      @metadata ||= begin
+        Psych.load(extract_metadata, symbolize_names: true).tap do |metadata|
+          raise Parser::Error.new(file: path, msg: 'Unable to locate metadata at the top of the markdown') unless metadata.present?
+        end
+      end
+    rescue Psych::SyntaxError => e
+      raise Parser::Error.new(file: path, error: e)
     end
 
     def simple_attributes


### PR DESCRIPTION
We don't verify the metadata, but we do now add some location info
so that it's possible to tell which file has the problem—rather than
having to search through every single chapter to find the extra space
in the indentation...