### PR TITLE
WEB-3565: Adding support for "auto" numbered chapters and sections

### DIFF
--- a/app/lib/parser/book_segments.rb
+++ b/app/lib/parser/book_segments.rb
@@ -10,6 +10,7 @@ module Parser
 
     def parse
       sections = grouped_segments.map.with_index { |segments, idx| parse_section(segments, idx) }
+      apply_auto_numbering(sections)
       Book.new(title: yaml[:title], sections: sections, git_commit_hash: git_hash)
     end
 
@@ -43,6 +44,17 @@ module Parser
       yaml[:segments].filter { |segment| VALID_SEGMENTS.include?(segment[:kind]) }
                      .slice_before { |segment| segment[:kind] == 'section' }
                      .filter { |group| group.first[:kind] == 'section' }
+    end
+
+    def apply_auto_numbering(sections)
+      section_index = 0
+      chapter_index = 0
+      sections.each do |section|
+        section_index = section.auto_number(section_index)
+        section.chapters.each do |chapter|
+          chapter_index = chapter.auto_number(chapter_index)
+        end
+      end
     end
   end
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -4,6 +4,7 @@
 class Chapter
   include ActiveModel::Model
   include ActiveModel::Serializers::JSON
+  include Concerns::AutoNumberable
   include Concerns::ImageAttachable
   include Concerns::MarkdownRenderable
   include Concerns::TitleCleanser

--- a/app/models/concerns/auto_numberable.rb
+++ b/app/models/concerns/auto_numberable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Concerns
+  # Adds a method to assist with auto numbering of objects
+  module AutoNumberable
+    extend ActiveSupport::Concern
+
+    included do
+      attr_accessor :number
+    end
+
+    # Takes the number of the previous object, and returns the new, updated one
+    def auto_number(index)
+      return number.to_i unless number == 'auto'
+
+      new_index = index + 1
+      self.number = new_index.to_s
+      new_index
+    end
+  end
+end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -4,6 +4,7 @@
 class Section
   include ActiveModel::Model
   include ActiveModel::Serializers::JSON
+  include Concerns::AutoNumberable
   include Concerns::ImageAttachable
   include Concerns::MarkdownRenderable
   include Concerns::TitleCleanser


### PR DESCRIPTION
Instead of providing a display number string for each chapter, you can instead put the word `auto`. This will work out the appropriate chapter number from the previously numbered chapter.

It will try to parse each chapter number string as an integer. This allows starting the numbered chapters with an offset.