### PR TITLE
WEB-3583: Allow book "segments" to be specified in a manifest file

### DIFF
--- a/app/commands/robles_cli.rb
+++ b/app/commands/robles_cli.rb
@@ -78,7 +78,7 @@ class RoblesCli < Thor
   def book_guardfile
     <<~GUARDFILE
       guard 'livereload' do
-        watch(%r{publish\.yaml$})
+        watch(%r{[a-zA-Z0-9\-_]+\.yaml$})
         watch(%r{.+\.(md|markdown)$})
       end
     GUARDFILE

--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -21,7 +21,8 @@ module Parser
     end
 
     def load_book_segments
-      @book = Parser::BookSegments.new(file: file).parse
+      segment_file = apply_path(publish_file[:manifest_file] || file)
+      @book = Parser::BookSegments.new(file: segment_file).parse
     end
 
     def apply_additonal_metadata


### PR DESCRIPTION
This was requested by the cookbook team so that they can auto-generate
the manifest file from the directory structure. It first looks for a
manifest_file attribute in publish.yaml, before falling back to using
the publish.yaml itself.

I don't expect that this will be useful outside cookbooks.