### PR TITLE
WEB-3617: Making the description field markdown compatible

### DIFF
--- a/app/lib/linting/metadata/publish_attributes.rb
+++ b/app/lib/linting/metadata/publish_attributes.rb
@@ -4,7 +4,7 @@ module Linting
   module Metadata
     # Check for the required attributes in the publish.yaml file
     class PublishAttributes
-      REQUIRED_ATTRIBUTES = %i[sku edition title description released_at authors segments materials_url
+      REQUIRED_ATTRIBUTES = %i[sku edition title description_md released_at authors segments materials_url
                                cover_image version_description difficulty platform language editor
                                short_description].freeze
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -7,7 +7,7 @@ class Book
   include Concerns::ImageAttachable
   include Concerns::MarkdownRenderable
 
-  attr_accessor :sku, :edition, :title, :description, :released_at, :sections, :git_commit_hash,
+  attr_accessor :sku, :edition, :title, :description_md, :released_at, :sections, :git_commit_hash,
                 :materials_url, :cover_image, :gallery_image, :twitter_card_image,
                 :trailer_video_url, :version_description, :professional, :difficulty,
                 :platform, :language, :editor, :domains, :categories, :who_is_this_for_md,
@@ -19,6 +19,7 @@ class Book
   attr_image :twitter_card_image_url, source: :twitter_card_image
   attr_markdown :who_is_this_for, source: :who_is_this_for_md, file: false
   attr_markdown :covered_concepts, source: :covered_concepts_md, file: false
+  attr_markdown :description, source: :description_md, file: false
 
   validates :sku, :edition, :title, presence: true
   validates_inclusion_of :difficulty, in: %w[beginner intermediate advanced]

--- a/app/server/views/index.html.erb
+++ b/app/server/views/index.html.erb
@@ -12,7 +12,7 @@
           <%= book.version_description %>
         </span>  
 
-        <p class="l-margin-18 l-font-header l-collection-hero__copy-markdown"><%= book.description %></p>
+        <p class="l-margin-18 l-font-header l-collection-hero__copy-markdown"><%= book.short_description %></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This means it'll have to be renamed description_md in publish.yaml, but
I think that's a sensible thing to do to ensure that it is obvious that
it accepts markdown.