### PR TITLE
WEB-3637: Adding amazon_url and ISBN as book attributes

### DIFF
--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -11,7 +11,7 @@ module Parser
                                version_description professional difficulty platform
                                language editor domains categories who_is_this_for_md
                                covered_concepts_md hide_chapter_numbers in_flux forum_url
-                               pages short_description recommended_skus].freeze
+                               pages short_description recommended_skus isbn amazon_url].freeze
 
     attr_reader :book
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -13,7 +13,7 @@ class Book
                 :platform, :language, :editor, :domains, :categories, :who_is_this_for_md,
                 :covered_concepts_md, :root_path, :hide_chapter_numbers, :in_flux,
                 :forum_url, :pages, :short_description, :recommended_skus, :contributors,
-                :price_band
+                :price_band, :isbn, :amazon_url
   attr_image :cover_image_url, source: :cover_image
   attr_image :gallery_image_url, source: :gallery_image
   attr_image :twitter_card_image_url, source: :twitter_card_image
@@ -40,6 +40,6 @@ class Book
       professional: nil, difficulty: nil, platform: nil, language: nil, editor: nil, domains: [],
       categories: [], who_is_this_for: nil, covered_concepts: nil, hide_chapter_numbers: nil,
       in_flux: nil, forum_url: nil, pages: nil, short_description: nil, recommended_skus: [],
-      contributors: [], price_band: nil }.stringify_keys
+      contributors: [], price_band: nil, isbn: nil, amazon_url: nil }.stringify_keys
   end
 end


### PR DESCRIPTION
I've reviewed publish.yaml in bkk and checked that we have all the
attributes covered. We now do =)