### PR TITLE
v1.0.8: Hit the 🐌 on the head

### DIFF
--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -6,7 +6,7 @@ module Parser
     include Util::PathExtraction
     include Linting::FileExistenceChecker
 
-    VALID_BOOK_ATTRIBUTES = %i[sku edition title description released_at materials_url
+    VALID_BOOK_ATTRIBUTES = %i[sku edition title description_md released_at materials_url
                                cover_image gallery_image twitter_card_image trailer_video_url
                                version_description professional difficulty platform
                                language editor domains categories who_is_this_for_md

--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -11,7 +11,7 @@ module Parser
                                version_description professional difficulty platform
                                language editor domains categories who_is_this_for_md
                                covered_concepts_md hide_chapter_numbers in_flux forum_url
-                               pages short_description recommended_skus].freeze
+                               pages short_description recommended_skus isbn amazon_url].freeze
 
     attr_reader :book
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -13,7 +13,7 @@ class Book
                 :platform, :language, :editor, :domains, :categories, :who_is_this_for_md,
                 :covered_concepts_md, :root_path, :hide_chapter_numbers, :in_flux,
                 :forum_url, :pages, :short_description, :recommended_skus, :contributors,
-                :price_band
+                :price_band, :isbn, :amazon_url
   attr_image :cover_image_url, source: :cover_image
   attr_image :gallery_image_url, source: :gallery_image
   attr_image :twitter_card_image_url, source: :twitter_card_image
@@ -40,6 +40,6 @@ class Book
       professional: nil, difficulty: nil, platform: nil, language: nil, editor: nil, domains: [],
       categories: [], who_is_this_for: nil, covered_concepts: nil, hide_chapter_numbers: nil,
       in_flux: nil, forum_url: nil, pages: nil, short_description: nil, recommended_skus: [],
-      contributors: [], price_band: nil }.stringify_keys
+      contributors: [], price_band: nil, isbn: nil, amazon_url: nil }.stringify_keys
   end
 end


### PR DESCRIPTION
- Adding support for amazon_url and ISBN
