### PR TITLE
WEB-3823: Allows specification of image variants as attachments

### DIFF
--- a/app/commands/robles_cli.rb
+++ b/app/commands/robles_cli.rb
@@ -16,8 +16,7 @@ class RoblesCli < Thor
   option :local, type: :boolean
   def render
     book = runner.render(publish_file: options['publish_file'], local: options['local'])
-    p book.sections.first.chapters.last
-    p book.contributors.to_json
+    p book.cover_image_url.to_json
   end
 
   desc 'serve', 'starts local preview server'

--- a/app/lib/image_provider/extractor.rb
+++ b/app/lib/image_provider/extractor.rb
@@ -12,7 +12,7 @@ module ImageProvider
 
     def extract
       @images = image_paths.map do |path|
-        Image.with_representations(local_url: path[:absolute_path], sku: book.sku)
+        Image.with_representations({ local_url: path[:absolute_path], sku: book.sku }, variants: path[:variants])
       end
     end
 

--- a/app/lib/image_provider/markdown_image_extractor.rb
+++ b/app/lib/image_provider/markdown_image_extractor.rb
@@ -18,7 +18,11 @@ module ImageProvider
     end
 
     def image_record(url)
-      { relative_path: cleanpath(url), absolute_path: cleanpath(apply_path(url)) }
+      {
+        relative_path: cleanpath(url),
+        absolute_path: cleanpath(apply_path(url)),
+        variants: ImageRepresentation::DEFAULT_WIDTHS.keys
+      }
     end
 
     def cleanpath(path)

--- a/app/lib/image_provider/provider.rb
+++ b/app/lib/image_provider/provider.rb
@@ -27,8 +27,8 @@ module ImageProvider
     def representations_for_local_url(url)
       clean_url = Pathname.new(url).cleanpath.to_s
       extractor.images
-               .find { |image| image.local_url == clean_url }
-               &.representations
+               .filter { |image| image.local_url == clean_url }
+               .flat_map(&:representations)
     end
 
     def extractor

--- a/app/lib/parser/publish.rb
+++ b/app/lib/parser/publish.rb
@@ -7,9 +7,9 @@ module Parser
     include Linting::FileExistenceChecker
 
     VALID_BOOK_ATTRIBUTES = %i[sku edition title description_md released_at materials_url
-                               cover_image gallery_image twitter_card_image trailer_video_url
-                               version_description professional difficulty platform
-                               language editor domains categories who_is_this_for_md
+                               cover_image gallery_image twitter_card_image artwork_image icon_image
+                               trailer_video_url version_description professional difficulty
+                               platform language editor domains categories who_is_this_for_md
                                covered_concepts_md hide_chapter_numbers in_flux forum_url
                                pages short_description recommended_skus isbn amazon_url].freeze
 

--- a/app/lib/renderer/image_attachable.rb
+++ b/app/lib/renderer/image_attachable.rb
@@ -15,8 +15,7 @@ module Renderer
       return if image_provider.blank?
 
       object.image_attachment_loop do |local_url|
-        representations = image_provider.representations_for_local_url(local_url)
-        representations.find { |r| r.width == :original }.remote_url
+        image_provider.representations_for_local_url(local_url)
       end
     end
   end

--- a/app/lib/renderer/image_attributes.rb
+++ b/app/lib/renderer/image_attributes.rb
@@ -19,6 +19,8 @@ module Renderer
 
     def representations(local_url)
       image_provider.representations_for_local_url(local_url)
+                    .filter { |r| ImageRepresentation::DEFAULT_WIDTHS.keys.include?(r.variant) }
+                    .uniq(&:variant)
     end
 
     def class_list(alt_text)

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,15 +8,17 @@ class Book
   include Concerns::MarkdownRenderable
 
   attr_accessor :sku, :edition, :title, :description_md, :released_at, :sections, :git_commit_hash,
-                :materials_url, :cover_image, :gallery_image, :twitter_card_image,
-                :trailer_video_url, :version_description, :professional, :difficulty,
+                :materials_url, :cover_image, :gallery_image, :twitter_card_image, :artwork_image,
+                :icon_image, :trailer_video_url, :version_description, :professional, :difficulty,
                 :platform, :language, :editor, :domains, :categories, :who_is_this_for_md,
                 :covered_concepts_md, :root_path, :hide_chapter_numbers, :in_flux,
                 :forum_url, :pages, :short_description, :recommended_skus, :contributors,
                 :price_band, :isbn, :amazon_url
-  attr_image :cover_image_url, source: :cover_image
+  attr_image :cover_image_url, source: :cover_image, variants: %i[original w594 w300]
   attr_image :gallery_image_url, source: :gallery_image
-  attr_image :twitter_card_image_url, source: :twitter_card_image
+  attr_image :twitter_card_image_url, source: :twitter_card_image, variants: %i[original w1800]
+  attr_image :artwork_image_url, source: :artwork_image, variants: %i[original w180]
+  attr_image :icon_image_url, source: :icon_image, variants: %i[original w180]
   attr_markdown :who_is_this_for, source: :who_is_this_for_md, file: false
   attr_markdown :covered_concepts, source: :covered_concepts_md, file: false
   attr_markdown :description, source: :description_md, file: false

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -37,11 +37,12 @@ class Book
   # Used for serialisation
   def attributes
     { sku: nil, edition: nil, title: nil, description: nil, released_at: nil, sections: [],
-      git_commit_hash: nil, materials_url: nil, cover_image_url: nil, gallery_image_url: nil,
-      twitter_card_image_url: nil, trailer_video_url: nil, version_description: nil,
-      professional: nil, difficulty: nil, platform: nil, language: nil, editor: nil, domains: [],
-      categories: [], who_is_this_for: nil, covered_concepts: nil, hide_chapter_numbers: nil,
-      in_flux: nil, forum_url: nil, pages: nil, short_description: nil, recommended_skus: [],
-      contributors: [], price_band: nil, isbn: nil, amazon_url: nil }.stringify_keys
+      git_commit_hash: nil, materials_url: nil, cover_image_url: [], gallery_image_url: [],
+      twitter_card_image_url: [], artwork_image_url: [], icon_image_url: [],
+      trailer_video_url: nil, version_description: nil, professional: nil, difficulty: nil,
+      platform: nil, language: nil, editor: nil, domains: [], categories: [], who_is_this_for: nil,
+      covered_concepts: nil, hide_chapter_numbers: nil, in_flux: nil, forum_url: nil, pages: nil,
+      short_description: nil, recommended_skus: [], contributors: [], price_band: nil, isbn: nil,
+      amazon_url: nil }.stringify_keys
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -8,9 +8,10 @@ class Image
 
   attr_accessor :local_url, :representations
 
-  def self.with_representations(attributes = {})
+  def self.with_representations(attributes = {}, variants: nil)
+    variants ||= ImageRepresentation::DEFAULT_WIDTHS.keys
     new(attributes).tap do |image|
-      image.representations = ImageRepresentation::WIDTHS.keys.map do |width|
+      image.representations = variants.map do |width|
         ImageRepresentation.new(width: width, image: image)
       end
     end
@@ -48,9 +49,9 @@ class Image
         next
       end
 
-      logger.info "Generating #{representation.width}px for #{local_url}"
+      logger.info "Generating #{representation.width} variant for #{local_url}"
       representation.generate
-      logger.info "Uploading #{representation.width}px for #{local_url}"
+      logger.info "Uploading #{representation.width} variant for #{local_url}"
       representation.upload
     end
   end

--- a/app/models/image_representation.rb
+++ b/app/models/image_representation.rb
@@ -3,15 +3,24 @@
 # Defines a specific size of an image
 class ImageRepresentation
   include ActiveModel::Model
+  include ActiveModel::Serializers::JSON
   include ImageProvider::Concerns::Resizable
   include ImageProvider::Concerns::Uploadable
 
-  WIDTHS = {
+  DEFAULT_WIDTHS = {
     small: 150,
     medium: 300,
     large: 700,
     original: nil
   }.freeze
+
+  OTHER_WIDTHS = {
+    w180: 180,
+    w300: 300,
+    w594: 594
+  }.freeze
+
+  WIDTHS = DEFAULT_WIDTHS.merge(OTHER_WIDTHS).freeze
 
   attr_accessor :width, :image
 
@@ -35,5 +44,13 @@ class ImageRepresentation
 
   def source_url
     image.local_url
+  end
+
+  # Used for serialisation
+  alias url remote_url
+  alias variant width
+
+  def attributes
+    { url: nil, variant: nil }
   end
 end


### PR DESCRIPTION
This adds the new image types that are required for display across
the site. It also changes the upload API, where image URLs are now
provided as an array of objects, each with `url` and `variant` keys.