### PR TITLE
WEB-3827: Adding a new edition attribute to vend.yaml

### DIFF
--- a/app/lib/linting/linter.rb
+++ b/app/lib/linting/linter.rb
@@ -46,7 +46,7 @@ module Linting
 
       if file_exists?(vend_file)
         with_spinner(title: 'Validating {{bold:vend.yaml}}', show: show_ui) do
-          annotations.concat(Linting::VendLinter.new(file: vend_file).lint)
+          annotations.concat(Linting::VendLinter.new(file: vend_file).lint(options: options))
         end
       else
         puts CLI::UI.fmt('{{x}} Unable to find {{bold:vend.yaml}}--skipping validation.')

--- a/app/lib/linting/metadata/edition_reference.rb
+++ b/app/lib/linting/metadata/edition_reference.rb
@@ -34,13 +34,15 @@ module Linting
           locate_edition_reference.merge(
             absolute_path: file,
             annotation_level: 'failure',
-            message: "The edition attribute in `publish.yaml` (#{edition_from_metadata}) should be the same as the one\nspecified in the git branch name (#{current_branch}).",
+            message: "The edition attribute in #{Pathname.new(file).basename} (#{edition_from_metadata}) should be the same as the one\nspecified in the git branch name (#{current_branch}).",
             title: 'Invalid edition specified'
           )
         )
       end
 
-      def locate_edition_reference
+      def locate_edition_reference # rubocop:disable Metrics/MethodLength
+        return { start_line: 0, end_line: 0 } unless attributes[:edition].present?
+
         IO.foreach(file).with_index do |line, line_number|
           next unless line.include?('edition:')
 

--- a/app/lib/linting/vend_linter.rb
+++ b/app/lib/linting/vend_linter.rb
@@ -3,7 +3,7 @@
 module Linting
   # Lints vend.yaml
   class VendLinter # rubocop:disable Metrics/ClassLength
-    VALID_PRICE_BANDS = %w(free 2020_full_book 2020_short_book 2020_deprecated_book).freeze
+    VALID_PRICE_BANDS = %w[free 2020_full_book 2020_short_book 2020_deprecated_book].freeze
     attr_reader :file, :vend_file
 
     def initialize(file:)
@@ -11,12 +11,13 @@ module Linting
       @annotations = []
     end
 
-    def lint
+    def lint(options: {})
       load_file
       return @annotations unless @annotations.empty?
 
       check_price_band
       check_total_percentage
+      @annotations.concat(Linting::Metadata::EditionReference.lint(file: file, attributes: vend_file)) unless options['without-edition']
       return @annotations unless @annotations.empty?
 
       check_for_razeware_user

--- a/app/lib/parser/vend.rb
+++ b/app/lib/parser/vend.rb
@@ -8,7 +8,8 @@ module Parser
     def parse
       {
         contributors: contributors,
-        price_band: vend_file[:price_band]
+        price_band: vend_file[:price_band],
+        edition: vend_file[:edition]
       }
     end
 


### PR DESCRIPTION
This is intended as a check to ensure that vend.yaml is reviewed before
a new release can be published.