### PR TITLE
WEB-3969: Improvements to local server

### DIFF
--- a/app/server/robles_server.rb
+++ b/app/server/robles_server.rb
@@ -6,6 +6,7 @@ class RoblesServer < Sinatra::Application
   set :bind, '0.0.0.0'
   set :views, __dir__ + '/views'
   set :public_folder, __dir__ + '/public'
+  set :static_cache_control, [max_age: 0]
 
   use Rack::LiveReload, host: '0.0.0.0'
 
@@ -13,6 +14,10 @@ class RoblesServer < Sinatra::Application
     def chapter_path(chapter)
       "/chapters/#{chapter.slug}"
     end
+  end
+
+  before do
+    cache_control max_age: 0
   end
 
   get '/' do

--- a/app/server/robles_server.rb
+++ b/app/server/robles_server.rb
@@ -69,6 +69,6 @@ class RoblesServer < Sinatra::Application
   end
 
   def acceptable_image_extension(extension)
-    %w[jpg png gif].include?(extension.downcase)
+    %w[jpg jpeg png gif].include?(extension.downcase)
   end
 end


### PR DESCRIPTION
- Add support for serving images with a `jpeg` extension
- Prevents caching of all files by browser. I think.

