### PR TITLE
WEB-4019: Disabling the vend.yaml version check

### DIFF
--- a/app/lib/linting/vend_linter.rb
+++ b/app/lib/linting/vend_linter.rb
@@ -17,7 +17,8 @@ module Linting
 
       check_price_band
       check_total_percentage
-      @annotations.concat(Linting::Metadata::BranchName.lint(file: file, attributes: vend_file, version_attribute: :edition)) unless options['without-edition']
+      # Disabling the branch version check for now. Allowing publication for review
+      # @annotations.concat(Linting::Metadata::BranchName.lint(file: file, attributes: vend_file, version_attribute: :edition)) unless options['without-edition']
       return @annotations unless @annotations.empty?
 
       check_for_razeware_user


### PR DESCRIPTION
This will allow team members to preview the published versions before
the version check is completed