### PR TITLE
WEB-4049: Adding support for images with more than one . in their name

### DIFF
--- a/app/server/robles_book_server.rb
+++ b/app/server/robles_book_server.rb
@@ -34,9 +34,9 @@ class RoblesBookServer < Sinatra::Application
         layout: :'books/layout.html'
   end
 
-  get '/assets/*.*' do
-    local_url = File.join('/data/src/', params[:splat].join('.'))
-    raise Sinatra::NotFound unless acceptable_image_extension(params[:splat].second) && File.exist?(local_url)
+  get '/assets/*' do
+    local_url = File.join('/data/src/', params[:splat])
+    raise Sinatra::NotFound unless acceptable_image_extension(File.extname(local_url)) && File.exist?(local_url)
 
     send_file(local_url)
   end
@@ -74,6 +74,6 @@ class RoblesBookServer < Sinatra::Application
   end
 
   def acceptable_image_extension(extension)
-    %w[jpg jpeg png gif].include?(extension.downcase)
+    %w[jpg jpeg png gif].include?(extension.sub('.', '').downcase)
   end
 end

--- a/app/server/robles_video_server.rb
+++ b/app/server/robles_video_server.rb
@@ -48,9 +48,9 @@ class RoblesVideoServer < Sinatra::Application
         layout: :'videos/layout.html'
   end
 
-  get '/assets/*.*' do
-    local_url = File.join('/data/src/', params[:splat].join('.'))
-    raise Sinatra::NotFound unless acceptable_image_extension(params[:splat].second) && File.exist?(local_url)
+  get '/assets/*' do
+    local_url = File.join('/data/src/', params[:splat])
+    raise Sinatra::NotFound unless acceptable_image_extension(File.extname(local_url)) && File.exist?(local_url)
 
     send_file(local_url)
   end
@@ -81,6 +81,6 @@ class RoblesVideoServer < Sinatra::Application
   end
 
   def acceptable_image_extension(extension)
-    %w[jpg jpeg png gif].include?(extension.downcase)
+    %w[jpg jpeg png gif].include?(extension.sub('.', '').downcase)
   end
 end


### PR DESCRIPTION
This was causing the slide generator to fail with @1.5x.png files