### PR TITLE
WEB-4174: Adding support for dedications and team bios

### DIFF
--- a/app/lib/parser/book_segments.rb
+++ b/app/lib/parser/book_segments.rb
@@ -6,7 +6,7 @@ module Parser
     include Util::PathExtraction
     include Util::GitHashable
 
-    VALID_SEGMENTS = %w[section chapter].freeze
+    VALID_SEGMENTS = %w[section chapter dedications team-bios].freeze
 
     def parse
       sections = grouped_segments.map.with_index { |segments, idx| parse_section(segments, idx) }
@@ -26,10 +26,10 @@ module Parser
     end
 
     def parse_chapter(segment, index)
-      raise 'Invalid segment kind' unless segment[:kind] == 'chapter'
+      raise 'Invalid segment kind' unless %w[chapter dedications team-bios].include?(segment[:kind])
 
       markdown_file = apply_path(segment[:path])
-      Chapter.new(markdown_file: markdown_file, ordinal: index, root_path: Pathname.new(markdown_file).dirname.to_s).tap do |chapter|
+      Chapter.new(markdown_file: markdown_file, ordinal: index, root_path: Pathname.new(markdown_file).dirname.to_s, kind: segment[:kind]).tap do |chapter|
         ChapterMetadata.new(chapter).apply!
       end
     end

--- a/app/lib/renderer/markdown_file_renderer.rb
+++ b/app/lib/renderer/markdown_file_renderer.rb
@@ -6,8 +6,7 @@ module Renderer
     include Util::Logging
     include Parser::FrontmatterMetadataFinder
 
-    attr_reader :path
-    attr_reader :image_provider
+    attr_reader :path, :image_provider
 
     def initialize(path:, image_provider: nil)
       @path = path
@@ -17,7 +16,7 @@ module Renderer
     def render
       logger.debug 'MarkdownFileRenderer::render'
       remove_h1(doc)
-      rw_renderer.render(doc)
+      fix_team_bio_markup(rw_renderer.render(doc))
     end
 
     def rw_renderer
@@ -53,6 +52,11 @@ module Renderer
         node.delete if node.type == :header && node.header_level.to_i == 1
       end
       document
+    end
+
+    def fix_team_bio_markup(html)
+      # It'd be nice to do this pre-render, but that involves allowing unsafe rendering of HTML
+      html.gsub(/<p>\$\[#tb\]<\/p>/, '<div>').gsub(/<p>\$\[tb#\]<\/p>/, '</div>')
     end
 
     def root_directory

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -9,14 +9,16 @@ class Chapter
   include Concerns::MarkdownRenderable
   include Concerns::TitleCleanser
 
-  attr_accessor :title, :number, :ordinal, :description, :authors, :markdown_file, :root_path, :free
-  attr_markdown :body, source: :markdown_file, file: true
+  attr_accessor :title, :number, :ordinal, :description, :authors, :markdown_file, :root_path, :free, :kind
+
+  attr_markdown :body, source: :markdown_file, file: true, wrapper_class: :wrapper_class
   validates :title, :number, :ordinal, :markdown_file, presence: true
 
   def initialize(attributes = {})
     super
     @authors ||= []
     @free ||= false
+    @kind ||= 'chapter'
   end
 
   def slug
@@ -31,5 +33,15 @@ class Chapter
   # Used for linting
   def validation_name
     title
+  end
+
+  # For wrapping content
+  def wrapper_class
+    p kind
+    {
+      'chapter': nil,
+      'dedications': 'c-book-chapter__dedications',
+      'team-bios': 'c-book-chapter__team'
+    }[kind.to_sym]
   end
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -37,11 +37,10 @@ class Chapter
 
   # For wrapping content
   def wrapper_class
-    p kind
     {
       'chapter': nil,
       'dedications': 'c-book-chapter__dedications',
       'team-bios': 'c-book-chapter__team'
-    }[kind.to_sym]
+    }[kind&.to_sym]
   end
 end

--- a/app/server/views/books/chapter.html.erb
+++ b/app/server/views/books/chapter.html.erb
@@ -63,7 +63,9 @@
             <div>
               <span class="l-font-42 l-margin-6"><%= chapter.title %></span>
               <span class="l-font-header l-font-17 l-font-normal l-no-font-spacing l-margin-6 l-line-height-1125">
-                Written by <%= chapter.authors.map(&:username).to_sentence %>
+                <% if chapter.authors.filter { |author| author.role == 'author' }.present? %>
+                  Written by <%= chapter.authors.filter { |author| author.role == 'author' }.map(&:username).to_sentence %>
+                <% end %>
               </span>
             </div>
           </h1>

--- a/app/server/views/styles/components/content.scss
+++ b/app/server/views/styles/components/content.scss
@@ -1194,6 +1194,10 @@ article.c-written-tutorial{
  ========================================================================== */
 
  .c-book-chapter__team {
+  h2 {
+    margin-bottom: 24px;
+  }
+
   padding-top: 24px;
 
   @include breakpoint("mobile-large"){
@@ -1212,13 +1216,11 @@ article.c-written-tutorial{
   figure {
     width: 180px;
     min-width: 180px;
-    height: 180px;
     margin-right: 24px;
 
     @include breakpoint("mobile-large"){
       width: 60px;
       min-width: 60px;
-      height: 60px;
       margin-right: 15px;
     }
 
@@ -1237,6 +1239,7 @@ article.c-written-tutorial{
         font-size: 1.6875rem; /* 27/16 */
         font-family: $header;
         font-weight: 700;
+        line-height: 0;
 
         @include breakpoint("mobile-large"){
           font-size: 1.1875rem; /* 19/16 */

--- a/app/server/views/styles/components/content.scss
+++ b/app/server/views/styles/components/content.scss
@@ -17,6 +17,8 @@
  *
  * 5. Book Chapter
  *
+ * 5a. Book Chapter (Dedications)
+ *
  */
 
 /* ==========================================================================
@@ -177,6 +179,24 @@ article.c-written-tutorial{
     @include breakpoint("mobile-large"){
       padding: 0;
       margin-top: 24px;
+    }
+
+    .c-draper-obfuscate-nudge {
+      padding-top: 18px !important;
+      margin-top: 30px !important;
+      margin-bottom: 30px !important;
+
+      p {
+        font-family: $header !important;
+      }
+
+      .l-obfuscated-text {
+        display: inline-block;
+        width: 104px;
+        text-align: center;
+        background: #F4C3C3;
+      }
+
     }
 
     .c-written-tutorial__content-footer{
@@ -1147,4 +1167,94 @@ article.c-written-tutorial{
   }
 
 }
+
+/* ==========================================================================
+ 5a. Book Chapter (Dedications)
+ ========================================================================== */
+
+.c-book-chapter__dedications {
+  max-width: 568px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 18px;
+
+  p {
+    text-align: center;
+
+    &:nth-child(even) {
+      margin-top: 12px !important;
+      margin-bottom: 48px;
+    }
+
+  }
+}
+
+/* ==========================================================================
+ 5b. Book Chapter (Team)
+ ========================================================================== */
+
+ .c-book-chapter__team {
+  padding-top: 24px;
+
+  @include breakpoint("mobile-large"){
+    padding-top: 15px;
+  }
+
+  > div {
+    display: flex;
+    margin-bottom: 45px;
+
+    @include breakpoint("mobile-large"){
+      margin-bottom: 24px;
+    }
+  }
+
+  figure {
+    width: 180px;
+    min-width: 180px;
+    height: 180px;
+    margin-right: 24px;
+
+    @include breakpoint("mobile-large"){
+      width: 60px;
+      min-width: 60px;
+      height: 60px;
+      margin-right: 15px;
+    }
+
+    img {
+      width: 100%;
+      height: 100%;
+    }
+
+  }
+
+  p {
+    margin: 0 !important;
+
+    strong {
+      &:first-child {
+        font-size: 1.6875rem; /* 27/16 */
+        font-family: $header;
+        font-weight: 700;
+
+        @include breakpoint("mobile-large"){
+          font-size: 1.1875rem; /* 19/16 */
+        }
+
+      }
+    }
+
+  }
+
+  .l-image-bordered {
+    img {
+      @include breakpoint("mobile-large"){
+        border-width: 4px !important;
+      }
+    }
+  }
+
+
+ }
 


### PR DESCRIPTION
Adds support for two new page types:

- `dedications`
- `team-bios`

As part of this, the following has changed with the markdown rendering engine:

- Allow specifying a class for a wrapper `<div>` on the markdown attribute
- Process the special pagesetting commands on the team bios page

@jellodiil A few small changes need to be made to the repos, but not that much:

- Dedications and team bios chapters need moving after the first section intro
- The Dedications title needs to be `<h1>` so that it gets ignored
- The team-bios subheadings (for each department) need to be `<h2>`
- The images in the team bios page need to be `bordered`
- Both pages need the standard chapter metadata adding at the top

This should still render identically in Deckle

![image](https://user-images.githubusercontent.com/658798/117480256-46d13d00-af59-11eb-9eca-15a51f290a4c.png)

![image](https://user-images.githubusercontent.com/658798/117480275-4df84b00-af59-11eb-803c-9db9e745681a.png)
