### PR TITLE
WEB-4186 Use a hexdigest in image urls

### DIFF
--- a/app/lib/image_provider/book_extractor.rb
+++ b/app/lib/image_provider/book_extractor.rb
@@ -21,7 +21,7 @@ module ImageProvider
     end
 
     def uploaded_image_root_path
-      "books/#{book.sku}/images"
+      "books/#{Digest::SHA2.hexdigest(book.sku)}/images"
     end
 
     def image_paths # rubocop:disable Metrics/AbcSize

--- a/app/lib/image_provider/video_course_extractor.rb
+++ b/app/lib/image_provider/video_course_extractor.rb
@@ -17,7 +17,7 @@ module ImageProvider
     end
 
     def uploaded_image_root_path
-      "videos/#{video_course.shortcode}/images"
+      "videos/#{Digest::SHA2.hexdigest(video_course.shortcode)}/images"
     end
 
     def image_paths


### PR DESCRIPTION
Instead of using a sku or shortcode, this replaces it with a hexdigest
representation. This should help mitigate adblocking software from
blocking our images.