### PR TITLE
WEB-4314: Word count + warnings into robles

### DIFF
--- a/app/lib/cli/output_formatter.rb
+++ b/app/lib/cli/output_formatter.rb
@@ -14,9 +14,14 @@ module Cli
     end
 
     def render
-      return success if output.validated
-
-      failure
+      case [output.validated, output.annotations.blank?]
+      when [true, true]
+        success
+      when [true, false]
+        warnings
+      else
+        failure
+      end
     end
 
     def success
@@ -25,6 +30,17 @@ module Cli
         puts output.summary
         CLI::UI::Frame.divider('Details')
         puts output.text
+      end
+    end
+
+    def warnings
+      CLI::UI::Frame.open('{{x}} {{bold:robles}} Linting Warnings', color: :yellow) do
+        puts CLI::UI.fmt("{{warning:#{output.title}}}")
+        puts output.summary
+        CLI::UI::Frame.divider('Details')
+        puts output.text
+        CLI::UI::Frame.divider('{{x}} Individual Annotations')
+        output.annotations.each { |annotation| render_annotation(annotation) }
       end
     end
 

--- a/app/lib/linting/book_linter.rb
+++ b/app/lib/linting/book_linter.rb
@@ -64,7 +64,14 @@ module Linting
     def output # rubocop:disable Metrics/MethodLength
       return Linting::Output.new(output_details.merge(annotations: annotations)) if output_details.present?
 
-      if annotations.present?
+      if annotations.blank?
+        Linting::Output.new(
+          title: 'robles Linting Success',
+          summary: 'Your book repo looks great',
+          text: 'I have nothing else to say here...',
+          validated: true
+        )
+      elsif annotations.any? { _1.annotation_level.to_sym == :failure }
         Linting::Output.new(
           title: 'robles Linting Failure',
           summary: 'There was a problem with your book repository',
@@ -74,9 +81,10 @@ module Linting
         )
       else
         Linting::Output.new(
-          title: 'robles Linting Success',
-          summary: 'Your book repo looks great',
-          text: 'I have nothing else to say here...',
+          title: 'robles Linting Results',
+          summary: 'There are some warnings for your book repository',
+          text: 'There are no failures—but some warnings for you to take a look at. Please check the individual file annotations for details',
+          annotations: annotations,
           validated: true
         )
       end

--- a/app/lib/linting/markdown/renderable.rb
+++ b/app/lib/linting/markdown/renderable.rb
@@ -4,8 +4,6 @@ module Linting
   module Markdown
     # Check that the attributes marked as markdown renderable are valid
     module Renderable
-      WORD_LIMIT = 4000
-
       include Linting::FileExistenceChecker
 
       attr_reader :object
@@ -21,7 +19,7 @@ module Linting
             
             if is_file
               counter = Linting::Markdown::WordCounter.new(markdown)
-              annotations << word_count_annotation(content, counter.count) if counter.count > WORD_LIMIT
+              annotations << word_count_annotation(content, counter.count) if counter.exceeds_word_limit?
             end
           end
         end
@@ -33,7 +31,7 @@ module Linting
           end_line: 0,
           absolute_path: file,
           annotation_level: 'warning',
-          message: "The word count in #{Pathname.new(file).basename} is #{word_count}. This exceeds the allowable limit of #{WORD_LIMIT}",
+          message: "The word count in #{Pathname.new(file).basename} is #{word_count}. This exceeds the allowable limit of #{Linting::Markdown::WordCounter::WORD_LIMIT}",
           title: "Word limit exceeded in #{Pathname.new(file).basename}"
         )
       end

--- a/app/lib/linting/markdown/renderable.rb
+++ b/app/lib/linting/markdown/renderable.rb
@@ -4,6 +4,8 @@ module Linting
   module Markdown
     # Check that the attributes marked as markdown renderable are valid
     module Renderable
+      WORD_LIMIT = 4000
+
       include Linting::FileExistenceChecker
 
       attr_reader :object
@@ -13,12 +15,27 @@ module Linting
       end
 
       def lint_markdown_attributes
-        object.markdown_render_loop do |content, is_file|
-          markdown = is_file ? File.read(content) : content
-          # TODO: Do some checking here
-          content
+        [].tap do |annotations|
+          object.markdown_render_loop do |content, is_file|
+            markdown = is_file ? File.read(content) : content
+            
+            if is_file
+              counter = Linting::Markdown::WordCounter.new(markdown)
+              annotations << word_count_annotation(content, counter.count) if counter.count > WORD_LIMIT
+            end
+          end
         end
-        []
+      end
+
+      def word_count_annotation(file, word_count)
+        Linting::Annotation.new(
+          start_line: 0,
+          end_line: 0,
+          absolute_path: file,
+          annotation_level: 'warning',
+          message: "The word count in #{Pathname.new(file).basename} is #{word_count}. This exceeds the allowable limit of #{WORD_LIMIT}",
+          title: "Word limit exceeded in #{Pathname.new(file).basename}"
+        )
       end
     end
   end

--- a/app/lib/linting/markdown/word_counter.rb
+++ b/app/lib/linting/markdown/word_counter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Linting
+  module Markdown
+    class WordCounter
+      attr_reader :markdown, :doc
+
+      def initialize(markdown)
+        @markdown = markdown
+        @doc = CommonMarker.render_doc(markdown)
+      end
+
+      def count
+        @count ||= doc.walk
+                      .filter { %i[text code].include?(_1.type) }
+                      .map(&:string_content)
+                      .join
+                      .scan(/\S+/)
+                      .size
+      end
+    end
+  end
+end

--- a/app/lib/linting/markdown/word_counter.rb
+++ b/app/lib/linting/markdown/word_counter.rb
@@ -24,6 +24,10 @@ module Linting
       def exceeds_word_limit?
         count > WORD_LIMIT
       end
+
+      def word_limit
+        WORD_LIMIT
+      end
     end
   end
 end

--- a/app/lib/linting/markdown/word_counter.rb
+++ b/app/lib/linting/markdown/word_counter.rb
@@ -3,6 +3,8 @@
 module Linting
   module Markdown
     class WordCounter
+      WORD_LIMIT = 4000
+
       attr_reader :markdown, :doc
 
       def initialize(markdown)
@@ -17,6 +19,10 @@ module Linting
                       .join
                       .scan(/\S+/)
                       .size
+      end
+
+      def exceeds_word_limit?
+        count > WORD_LIMIT
       end
     end
   end

--- a/app/server/views/books/_index_table_of_contents.html.erb
+++ b/app/server/views/books/_index_table_of_contents.html.erb
@@ -13,6 +13,9 @@
         <div class="l-flex-align-start">
           <h4><a href="<%= url(chapter_path(chapter)) %>"><%= chapter.title %></a></h4>
           <% if chapter.free %><span class="o-badge">Free</span><% end %>
+          <% if exceeds_word_limit?(chapter) %>
+            <span class="o-badge o-badge-product o-badge-product--highlight">Word Count Exceeded</span>
+          <% end %>
         </div>
         <p><%= chapter.description %></p>
         <span class="c-tutorial-episode__number-badge data-tooltip--top-left">

--- a/app/server/views/books/chapter.html.erb
+++ b/app/server/views/books/chapter.html.erb
@@ -1,3 +1,9 @@
+<div class="o-alert l-alert-sticky <%= word_counter.exceeds_word_limit? ? 'o-alert--warning' : 'o-alert--info' %>">
+  Word count: <%= "#{word_counter.count} / #{word_counter.word_limit}" %>.
+  <%= "This chapter exceeds the word limit." if word_counter.exceeds_word_limit? %>
+</div>
+
+
 <header id="c-global-header" class="c-book-header" role="banner">
   <div class="l-flex-align-center--force">
 

--- a/app/server/views/styles/application.scss
+++ b/app/server/views/styles/application.scss
@@ -34,6 +34,7 @@
 // ---------
 @import 'objects/badges';
 @import 'objects/buttons';
+@import 'objects/messages';
 
 // Shame
 // ------

--- a/app/server/views/styles/objects/messages.scss
+++ b/app/server/views/styles/objects/messages.scss
@@ -1,0 +1,212 @@
+/**
+* Feedback banners and messages
+*
+* Notify the user when they've made a change via a form or to highlight news and announcements
+*
+* 1. Base DO NOT EDIT
+*
+* 2. Class Modifiers for success, warning, danger and info messages
+*
+* 3. Custom layout classes
+*/
+
+/* ==========================================================================
+1. Base
+========================================================================== */
+
+.o-alert{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: $border-radius;
+  min-height: 48px;
+  color: $white;
+  padding: 14px 15px;
+  position: relative;
+  font-size: 0.9375em;
+  margin-top: 10px;
+  
+  a{
+    color: $white;
+  }
+  
+  @include breakpoint("mobile"){
+    font-size: 0.875rem;
+  }
+  
+  .o-alert__close{
+    order: 10;
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    position: relative;
+    
+    svg{
+      width: 16px;
+      height: 16px;
+      fill: $white;
+      margin: -8px 0 0 -8px;
+    }
+  }
+  
+}
+
+@mixin badge{
+  position: absolute;
+  left: 15px;
+  top: 12px;
+  border-radius: $border-radius;
+  background: $white;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .33px;
+  padding: 5px 8px 4px;
+}
+
+/* ==========================================================================
+2. Class Modifiers for success, warning, danger and info messages
+========================================================================== */
+
+.o-alert--success{
+  background: $green-brand;
+  padding-left: 94px;
+  
+  &:before{
+    content: "success";
+    color: $green-brand;
+    @include badge;
+  }
+  
+}
+
+.o-alert--danger{
+  background: $red-pomegranate;
+  padding-left: 78px;
+  
+  &:before{
+    content: "error";
+    color: $red-pomegranate;
+    @include badge;
+  }
+  
+}
+
+.o-alert--warning{
+  background: $yellow-sin;
+  padding-left: 94px;
+  
+  &:before{
+    content: "warning";
+    color: $yellow-sin;
+    @include badge;
+  }
+  
+}
+
+.o-alert--tip{
+  background: $black-slate;
+  padding-left: 58px;
+  
+  &:before{
+    content: "tip";
+    color: $black-slate;
+    @include badge;
+  }
+  
+}
+
+.o-alert--info{
+  background: $black-slate;
+  padding-left: 68px;
+  
+  &:before{
+    content: "info";
+    color: $black-slate;
+    @include badge;
+  }
+  
+}
+
+.o-alert--archive{
+  background: $red-pomegranate;
+  padding-left: 90px;
+  
+  &:before{
+    content: "archive";
+    color: $red-pomegranate;
+    @include badge;
+  }
+  
+}
+
+.o-alert--announce{
+  background: $purple-scampi;
+  padding-left: 138px;
+  
+  &:before{
+    content: "announcement";
+    color: $purple-scampi;
+    @include badge;
+  }
+  
+}
+
+.o-alert--subscription{
+  background: $yellow-grandis;
+  color: $black-mine-shaft;
+  padding-left: 68px;
+  
+  &:before{
+    content: "info";
+    color: $yellow-grandis;
+    @include badge;
+    background: $black-mine-shaft;
+  }
+  
+}
+
+.o-alert--pro{
+  background: $blue-curious;
+  padding-left: 68px;
+  
+  &:before{
+    content: "pro";
+    @include badge;
+    background: $blue-curious;
+    border-radius: 0.5625rem; /* 9/16 */
+    border: 2px solid $white;
+    color: $white;
+    padding: 2px 7px;
+    top: 13px;
+  }
+  
+}
+
+
+/* ==========================================================================
+3. Custom layout classes
+========================================================================== */
+
+.l-alert-admin-top{
+  margin-bottom: 27px;
+}
+
+.l-alert-sticky{
+  position: fixed;
+  z-index: 999999;
+  bottom: 0;
+  width: 100%;
+  border-radius: 0;
+  
+  @include breakpoint("tablet"){
+    left: 0;
+    width: 100%;
+  }
+  
+}
+
+.l-alert-banner{
+  border-radius: 0;
+  margin-top: 0;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,16 @@ services:
     build: .
     volumes:
       - .:/app/robles
-      - ../video-aiar:/data/src
-      #- ../../books/mad:/data/src
+      # When working on videos
+      #- ../video-aiar:/data/src
+      # When working on books
+      - ../../books/alg:/data/src
+      # When working on pablo
+      #- ../../sites/pablo:/data/src
     command: bin/robles video serve
     env_file: .env
     environment:
-      - IMAGES_CDN_HOST=assets.pablo.raywenderlich.com
+      - IMAGES_CDN_HOST=assets.robles.raywenderlich.com
     ports:
       - "4567:4567"
       - "35729:35729"
@@ -17,5 +21,6 @@ services:
     image: browserless/chrome
     ports:
       - "3000:3000"
-    volumes:
-      - ../video-aiar:/data/src
+    # volumes:
+    # When working on videos
+    #   - ../video-aiar:/data/src


### PR DESCRIPTION
Adding a word counter for markdown that counts words that aren't in code blocks. It's not perfect—there are times when it joins words together unnecessarily, and times where it splits them up. However, I think that it's accurate enough for the guidance. As long as the teams use this metric for their word counts then it doesn't matter.

This adds listing warnings for book chapters that are over the word limit (4000):

<img width="967" alt="image" src="https://user-images.githubusercontent.com/658798/133504082-4a606092-2c08-4b52-8248-4251c31d479d.png">

These should be just warnings, and shouldn't cause lint to fail. I don't think.

Also, on the book overview page:

<img width="977" alt="image" src="https://user-images.githubusercontent.com/658798/133503782-2f32e306-d3cf-4f16-ad94-25533de81fb5.png">

And the chapter page itself:

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/658798/133503862-9fc0a04b-e82c-47f2-9920-95558005747d.png">

When it doesn't exceed the word limit, the chapter page just shows the count:

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/658798/133503988-92465f46-57eb-4bc1-8a59-6fed6780c835.png">
