### PR TITLE
WEB-4385: Switching from SHA256 to MD5 hashing algorithm

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -30,7 +30,7 @@ class Image
   end
 
   def key
-    @key ||= Digest::SHA256.file(local_url).hexdigest
+    @key ||= Digest::MD5.file(local_url).hexdigest
   end
 
   def extension


### PR DESCRIPTION
SHA256 is 256 bits = 64 (hex) characters
MD5 is 128 bits = 32 (hex) characters

So the hash in the filename should be half the length, which I think
is ok.

Note: every single video course and book that runs through CI after
this will re-upload all its images. I don't think that this is a
problem, but something to bear in mind. The old images will remain
on the CDN, so it shouldn't break anything. But we'll have duplicates
with different names.