### PR TITLE
WEB-4471: Adding $[//] as comment syntax in markdown files

### DIFF
--- a/app/lib/renderer/markdown_file_renderer.rb
+++ b/app/lib/renderer/markdown_file_renderer.rb
@@ -37,7 +37,9 @@ module Renderer
     def preproccessed_markdown
       @preproccessed_markdown ||= begin
         removing_pagesetting_notation = raw_content.gsub(/\$\[=[=sp]=\]/, '')
-        without_metadata(removing_pagesetting_notation.each_line)
+        # Any lines that include $[//] will be stripped from the raw markdown. Use these to make comments
+        removing_comments = removing_pagesetting_notation.each_line.reject { |line| line.include?('$[//]') }
+        without_metadata(removing_comments)
       end
     end
 

--- a/app/lib/renderer/markdown_timestamper.rb
+++ b/app/lib/renderer/markdown_timestamper.rb
@@ -18,7 +18,7 @@ module Renderer
       document.walk.each do |node|
         # We only care about paragraph nodes
         next unless node.type == :paragraph
-       
+
         # Get the plain text for this paragraph and tidy it up
         paragraph = node.to_plaintext.gsub("\n", ' ').strip
 
@@ -26,7 +26,7 @@ module Renderer
         next if paragraph.match?(/\$\[t=[\d:.]+\]/)
 
         word_count = paragraph.split.length
-      
+
         # Search the captions for a match for this paragraph
         match = (0..vtt.cues.length).map do |offset|
           vtt_wc = 0
@@ -38,14 +38,14 @@ module Renderer
             vtt_wc = caption.split.length
             i += 1
           end
-      
+
           # Match the word count
           caption = caption.split[0...paragraph.split.length].join(' ')
-          
+
           # Calculate the similarity
           [offset, Levenshtein.distance(caption, paragraph), caption, paragraph]
         end.min { |a, b| a[1] <=> b[1] }
-      
+
         cue = vtt.cues[match[0]]
         text = CommonMarker::Node.new(:text)
         text.string_content = "$[t=#{cue.start}]"


### PR DESCRIPTION
Adding this to a line in markdown will cause the entire line to be
ignored by the markdown processor. It can be anywhere on a line.