### PR TITLE
WEB-4523: Fixes a problem with clashing method names

### DIFF
--- a/app/lib/linting/image/attachable.rb
+++ b/app/lib/linting/image/attachable.rb
@@ -13,39 +13,41 @@ module Linting
       end
 
       def lint_attachments
-        non_existent_images.flat_map do |image|
-          locate_errors(image[:relative_path]).map do |location|
-            annotation(image, location)
+        _att_non_existent_images.flat_map do |image|
+          _att_locate_errors(image[:relative_path]).map do |location|
+            _att_annotation(image, location)
           end
         end
       end
 
-      def locate_errors(_image)
+      private
+
+      def _att_locate_errors(_image)
         [{
           start_line: 1,
           end_line: 1
         }]
       end
 
-      def message_for_image(image)
-        return 'This file does not exist.' unless file_exists?(image[:absolute_path], case_insensitive: true)
+      def _att_message_for_image(image)
+        return "This file (#{image[:relative_path]}) does not exist." unless file_exists?(image[:absolute_path], case_insensitive: true)
 
-        'This file does not exist. Check for case sensitivity—a very similarly named file does exist, but has different case.'
+        "This file (#{image[:relative_path]}) does not exist. Check for case sensitivity—a very similarly named file does exist, but has different case."
       end
 
-      def annotation(image, location)
+      def _att_annotation(image, location)
         Linting::Annotation.new(
           location.merge(
             absolute_path: '/data/src/publish.yaml', # WARNING: This is hardcoded and should probably be re-done
             annotation_level: 'failure',
-            message: message_for_image(image),
+            message: _att_message_for_image(image),
             title: 'Invalid image reference'
           )
         )
       end
 
-      def non_existent_images
-        @non_existent_images ||= object.image_attachment_paths.reject do |image|
+      def _att_non_existent_images
+        @_att_non_existent_images ||= object.image_attachment_paths.reject do |image|
           file_exists?(image[:absolute_path], case_insensitive: false)
         end
       end


### PR DESCRIPTION
Basically, some files we check both attached images and markdown images
which means that we use both the Markdown and the Attachable modules.
Trouble is, they shared some method naming, which means that we
overwrote one with the other.

This gives the similar methods in the two modules unique names, so they
no longer clash.

Also updates the error message to be more helpful.