### PR TITLE
WEB-4543: Fixes an issue with the zero-indexed parts on video courses

### DIFF
--- a/app/lib/parser/video_course.rb
+++ b/app/lib/parser/video_course.rb
@@ -38,7 +38,7 @@ module Parser
         parse_episode(episode)
       end
 
-      Part.new(ordinal: index, episodes: episodes).tap do |part|
+      Part.new(ordinal: index + 1, episodes: episodes).tap do |part|
         PartMetadata.new(part, metadata).apply!
       end
     end

--- a/app/server/views/videos/_index_table_of_contents.html.erb
+++ b/app/server/views/videos/_index_table_of_contents.html.erb
@@ -1,6 +1,6 @@
 <div class="l-book-toc l-margin-60 l-margin-mobile-large-40">
   <% video_course.parts.each do |part| %>
-    <h2><%= part.title %></h2>
+    <h2>Part <%= part.ordinal %>: <%= part.title %></h2>
     <div class="l-book-toc-section-description">
       <p>
         <%= part.description %>


### PR DESCRIPTION
This was a regression from the latest release of robles. Also updated
to show the part number in the local preview.