### PR TITLE
WEB-5461: Breaks episode titles to several lines

### DIFF
--- a/app/server/views/styles/components/slide.scss
+++ b/app/server/views/styles/components/slide.scss
@@ -146,18 +146,22 @@ $slide-ratio: 1.8;
 
     h2 {
       font-size: 16px * $slide-ratio;
-      line-height: 1;
+      line-height: 1.25;
       font-family: 'Relative', sans-serif;
       font-weight: 400;
       text-align: left;
       padding-bottom: 16px * $slide-ratio;
+      /* Max-width is roughly 55%, but percentage doesn't work cos absolute positioning... */
+      max-width: 587px * $slide-ratio;
     }
 
     h3 {
       font-size: 40px * $slide-ratio;
       font-family: 'Relative', sans-serif;
       font-weight: 400;
-      line-height: 1;
+      line-height: 1.25;
+      /* Max-width is roughly 55%, but percentage doesn't work cos absolute positioning... */
+      max-width: 587px * $slide-ratio;
     }
   }
 


### PR DESCRIPTION
Some video courses have Very Long Episode Titles.

They now break onto more than one line.

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/58082567/195892420-354c7c71-c70d-4d0a-bbff-ecc1ab610551.png">
