### PR TITLE
WEB-6165: Removes faraday retry middleware

### DIFF
--- a/app/lib/ci/linting_reporter.rb
+++ b/app/lib/ci/linting_reporter.rb
@@ -57,7 +57,6 @@ module Ci
 
     def middleware
       @middleware ||= Faraday::RackBuilder.new do |builder|
-        builder.use Faraday::Request::Retry, exceptions: [Octokit::ServerError]
         builder.use Octokit::Middleware::FollowRedirects
         builder.use Octokit::Response::RaiseError
         builder.use Octokit::Response::FeedParser

--- a/app/lib/repo_management/secrets.rb
+++ b/app/lib/repo_management/secrets.rb
@@ -77,7 +77,6 @@ module RepoManagement
 
     def middleware
       @middleware ||= Faraday::RackBuilder.new do |builder|
-        builder.use Faraday::Request::Retry, exceptions: [Octokit::ServerError]
         builder.use Octokit::Middleware::FollowRedirects
         builder.use Octokit::Response::RaiseError
         builder.use Octokit::Response::FeedParser


### PR DESCRIPTION
Which should allow secrets to be uploaded again, and linting to be reported