### PR TITLE
WEB-6519: Fix slides

### DIFF
--- a/app/commands/content_module_cli.rb
+++ b/app/commands/content_module_cli.rb
@@ -44,14 +44,14 @@ class ContentModuleCli < Thor
   option :app_port, type: :string, default: '4567', desc: 'Port of host running robles app server'
   option :snapshot_host, type: :string, default: 'snapshot', desc: 'Hostname of host running headless chrome'
   option :snapshot_port, type: :string, default: '3000', desc: 'Port of host running headless chrome'
-  option :out_dir, type: :string, default: '/data/src/artwork/slides', desc: 'Location to save the output slides'
+  option :out_dir, type: :string, default: '/data/src/artwork/video-title-slides', desc: 'Location to save the output slides'
   def slides
     module_file = options.fetch('module_file', runner.default_module_file)
     parser = Parser::Circulate.new(file: module_file)
     content_module = parser.parse
     options.delete('module_file')
     args = options.merge(data: content_module.lessons.flat_map(&:segments), snapshot_host: 'localhost').symbolize_keys
-    snapshotter = Snapshotter::Slides.new(**args)
+    snapshotter = Snapshotter::ContentModuleSlides.new(**args)
     snapshotter.generate
   end
 

--- a/app/commands/video_cli.rb
+++ b/app/commands/video_cli.rb
@@ -58,7 +58,7 @@ class VideoCli < Thor
     parser = Parser::Release.new(file: release_file)
     video_course = parser.parse
     args = options.merge(data: video_course.parts.flat_map(&:episodes)).symbolize_keys
-    snapshotter = Snapshotter::Slides.new(**args)
+    snapshotter = Snapshotter::VideoCourseSlides.new(**args)
     snapshotter.generate
   end
 

--- a/app/lib/parser/lesson_metadata.rb
+++ b/app/lib/parser/lesson_metadata.rb
@@ -5,7 +5,7 @@ module Parser
   class LessonMetadata
     include SimpleAttributes
 
-    VALID_SIMPLE_ATTRIBUTES = %i[title description ordinal].freeze
+    VALID_SIMPLE_ATTRIBUTES = %i[title description ordinal ref].freeze
 
     attr_accessor :lesson, :metadata
 

--- a/app/lib/snapshotter/content_module_slides.rb
+++ b/app/lib/snapshotter/content_module_slides.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Snapshotter
+  # Creates snapshots of all the slides in a content module
+  class ContentModule < Slides
+    def generate
+      data.each do |lesson|
+        lesson.segments.each do |segment|
+          next unless segment.is_a?(Video)
+
+          browser.goto("#{app_base}/slides/#{lesson.slug}/#{episode.slug}")
+          browser.screenshot(path: "#{out_dir}/#{lesson-ref}-#{episode.slug}.png", selector: '#slide-to-snapshot')
+        end
+      end
+    end
+  end
+end

--- a/app/lib/snapshotter/slides.rb
+++ b/app/lib/snapshotter/slides.rb
@@ -17,13 +17,11 @@ module Snapshotter
     end
 
     def generate
-      browser = Ferrum::Browser.new(url: "http://#{snapshot_host}:#{snapshot_port}", window_size: [1920, 1080], timeout: 15)
-      data.each do |episode|
-        next unless episode.is_a?(Video)
+      raise 'Override this in a subclass please'
+    end
 
-        browser.goto("#{app_base}/slides/#{episode.slug}")
-        browser.screenshot(path: "#{out_dir}/#{episode.slug}.png", selector: '#slide-to-snapshot')
-      end
+    def browser
+      @browser ||= Ferrum::Browser.new(url: "http://#{snapshot_host}:#{snapshot_port}", window_size: [1920, 1080], timeout: 15)
     end
 
     def app_base

--- a/app/lib/snapshotter/video_course_slides.rb
+++ b/app/lib/snapshotter/video_course_slides.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Snapshotter
+  # Creates snapshots of all the slides in a video course
+  class ContentModule < Slides
+    def generate
+      data.each do |episode|
+        next unless episode.is_a?(Video)
+
+        browser.goto("#{app_base}/slides/#{episode.slug}")
+        browser.screenshot(path: "#{out_dir}/#{episode.slug}.png", selector: '#slide-to-snapshot')
+      end
+    end
+  end
+end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -16,6 +16,10 @@ class Lesson
     @segments ||= []
   end
 
+  def slug
+    "#{ref}-#{title.parameterize}"
+  end
+
   # Used for serialisation
   def attributes
     { title: nil, description: nil, ordinal: nil, segments: [], ref: nil }.stringify_keys

--- a/app/server/robles_content_module_server.rb
+++ b/app/server/robles_content_module_server.rb
@@ -12,20 +12,20 @@ class RoblesContentModuleServer < Sinatra::Application
   use Rack::LiveReload, host: 'localhost', source: :vendored
 
   helpers do
-    def slide_path(segment)
-      "/slides/#{segment.slug}"
+    def slide_path(lesson, segment)
+      "/slides/#{lesson.slug}/#{segment.slug}"
     end
 
-    def transcript_path(segment)
-      "/transcripts/#{segment.slug}"
+    def transcript_path(lesson, segment)
+      "/transcripts/#{lesson.slug}/#{segment.slug}"
     end
 
-    def assessment_path(segment)
-      "/assessments/#{segment.slug}"
+    def assessment_path(lesson, segment)
+      "/assessments/#{lesson.slug}/#{segment.slug}"
     end
 
-    def text_path(segment)
-      "/texts/#{segment.slug}"
+    def text_path(lesson, segment)
+      "/texts/#{lesson.slug}/#{segment.slug}"
     end
 
     def class_for_domain(course)
@@ -56,48 +56,44 @@ class RoblesContentModuleServer < Sinatra::Application
     erb :'content_modules/index.html', locals: { content_module: @content_module, title: "robles Preview: #{@content_module.title}" }, layout: :'content_modules/layout.html'
   end
 
-  get '/slides/:slug' do
+  get '/slides/:lesson_slug/:slug' do
     @content_module = content_module(with_transcript: false)
-    segment = segment_for_slug(params[:slug])
+    lesson = lesson_for_slug(params[:lesson_slug])
+    segment = segment_for_slug(lesson, params[:slug])
     raise Sinatra::NotFound unless segment.present?
-
-    lesson = @content_module.lessons.find { |p| p.segments.include?(segment) }
 
     erb :'content_modules/segment_slide.html',
         locals: { segment:, lesson:, content_module: @content_module, title: "robles Preview: #{segment.title}" },
         layout: :'content_modules/layout.html'
   end
 
-  get '/transcripts/:slug' do
+  get '/transcripts/:lesson_slug/:slug' do
     @content_module = content_module(with_transcript: true)
-    segment = segment_for_slug(params[:slug])
+    lesson = lesson_for_slug(params[:lesson_slug])
+    segment = segment_for_slug(lesson, params[:slug])
     raise Sinatra::NotFound unless segment.present?
-
-    lesson = @content_module.lessons.find { |p| p.segments.include?(segment) }
 
     erb :'content_modules/segment_transcript.html',
         locals: { segment:, lesson:, content_module: @content_module, title: "robles Preview: #{segment.title}" },
         layout: :'content_modules/layout.html'
   end
 
-  get '/assessments/:slug' do
+  get '/assessments/:lesson_slug/:slug' do
     @content_module = content_module(with_transcript: false)
-    segment = segment_for_slug(params[:slug])
+    lesson = lesson_for_slug(params[:lesson_slug])
+    segment = segment_for_slug(lesson, params[:slug])
     raise Sinatra::NotFound unless segment.present?
-
-    lesson = @content_module.lessons.find { |p| p.segments.include?(segment) }
 
     erb :'content_modules/assessment.html',
         locals: { segment:, lesson:, content_module: @content_module, title: "robles Preview: #{segment.title}" },
         layout: :'content_modules/layout.html'
   end
 
-  get '/texts/:slug' do
+  get '/texts/:lesson_slug/:slug' do
     @content_module = content_module(with_transcript: false)
-    segment = segment_for_slug(params[:slug])
+    lesson = lesson_for_slug(params[:lesson_slug])
+    segment = segment_for_slug(lesson, params[:slug])
     raise Sinatra::NotFound unless segment.present?
-
-    lesson = @content_module.lessons.find { |p| p.segments.include?(segment) }
 
     erb :'content_modules/text.html',
         locals: {
@@ -139,8 +135,12 @@ class RoblesContentModuleServer < Sinatra::Application
     Linting::Markdown::WordCounter.new(markdown)
   end
 
-  def segment_for_slug(slug)
-    @content_module.lessons.flat_map(&:segments).find { |segment| segment.slug == slug }
+  def lesson_for_slug(slug)
+    @content_module.lessons.find { |lesson| lesson.slug == slug }
+  end
+
+  def segment_for_slug(lesson, slug)
+    lesson.segments.find { |segment| segment.slug == slug }
   end
 
   def module_file

--- a/app/server/views/content_modules/_index_table_of_contents.html.erb
+++ b/app/server/views/content_modules/_index_table_of_contents.html.erb
@@ -12,13 +12,13 @@
       <div class="c-tutorial-segment">
         <div class="l-flex-align-start">
           <% if segment.is_a?(Video) %>
-            <h4><a href="<%= url(transcript_path(segment)) %>"><%= segment.title %></a></h4>
+            <h4><a href="<%= url(transcript_path(lesson, segment)) %>"><%= segment.title %></a></h4>
             <% if segment.free %><span class="o-badge">Free</span><% end %>
-            <a href="<%= url(slide_path(segment)) %>" class="o-badge o-badge-product--highlight">slide</a>
+            <a href="<%= url(slide_path(lesson, segment)) %>" class="o-badge o-badge-product--highlight">slide</a>
           <% elsif segment.is_a?(Assessment) %>
-            <h4><a href="<%= url(assessment_path(segment)) %>"><%= segment.title %></a></h4>
+            <h4><a href="<%= url(assessment_path(lesson, segment)) %>"><%= segment.title %></a></h4>
           <% elsif segment.is_a?(Text) %>
-            <h4><a href="<%= url(text_path(segment)) %>"><%= segment.title %></a></h4>
+            <h4><a href="<%= url(text_path(lesson, segment)) %>"><%= segment.title %></a></h4>
           <% end %>
         </div>
         <p><%= segment.description %></p>

--- a/app/server/views/content_modules/_table_of_contents.html.erb
+++ b/app/server/views/content_modules/_table_of_contents.html.erb
@@ -26,7 +26,7 @@
             <ul class="c-box-list c-box-list--linked c-video-player__lesson-list c-video-player__lesson-list--open">
               <% lesson.segments.each do |segment| %>
                 <li class="<%= 'c-box-list__item--active' if segment == current_segment %>">
-                  <a href="<%= url(transcript_path(segment)) %>">
+                  <a href="<%= url(transcript_path(lesson, segment)) %>">
                     <span class="c-box-list__item-number"><%= segment.ref %>.</span>
                     <span class="c-box-list__item-title"><%= segment.title %></span>
                   </a>

--- a/app/server/views/content_modules/segment_slide.html.erb
+++ b/app/server/views/content_modules/segment_slide.html.erb
@@ -4,21 +4,16 @@
   </h1>
   <div class="slide-episode">
     <% if content_module.lessons.count> 1 %>
-      <h2>Lesson <%= lesson.ordinal %>: <%= lesson.title %>
-      </h2>
-      <% end %>
-        <h3>
-          <%=segment.ref%>. <%= segment.title %>
-        </h3>
+      <h2>Lesson <%= lesson.ref %>: <%= lesson.title %></h2>
+    <% end %>
+    <h3><%= segment.title %></h3>
   </div>
 
-  <div class="slide-domain--<%= class_for_domain(content_module) %>">
-
-  </div>
+  <div class="slide-domain--<%= class_for_domain(content_module) %>"></div>
 
   <% if content_module.featured_banner_image_url&.first&.url.present? %>
     <figure>
       <img src="<%= content_module.featured_banner_image_url&.first&.url %>">
     </figure>
-    <% end %>
+  <% end %>
 </div>


### PR DESCRIPTION
- Design didn't have the correct elements
- Server paths didn't include lessons, so not all slides were accessible
- Generator needs to support different settings for videos vs modules
- Default output location is different
- Ref wasn't being parsed correctly