### PR TITLE
WEB-6543: Updating linter file existence checker to work with subfiles

### DIFF
--- a/app/lib/linting/metadata/captions_file.rb
+++ b/app/lib/linting/metadata/captions_file.rb
@@ -40,13 +40,16 @@ module Linting
       def module_captions
         caption_files = ModuleFile.new(file:, attributes:).file_path_list
         caption_files.map do |file|
-          if yaml?(file)
+          captions_file = if yaml?(file)
             load_yaml(File.read(file)).deep_symbolize_keys[:captions_file]
           else
             @markdown_metadata = nil
             @path = file
             markdown_metadata[:captions_file]
           end
+          next unless captions_file.present?
+
+          [captions_file, file]
         end.compact
       end
 


### PR DESCRIPTION
Paths in markdown metadata should always be relative to the markdown file itself. This updates the file existence checker so that that is the case.