### PR TITLE
WEB-6559: Extract the vimeo_id from metadata, add to model, and push

### DIFF
--- a/app/lib/parser/video_metadata.rb
+++ b/app/lib/parser/video_metadata.rb
@@ -18,6 +18,8 @@ module Parser
     def apply!
       check_captions_path
       video.assign_attributes(simple_attributes)
+      # Need to extract the ID from the URL, if one has been provided
+      video.vimeo_id = metadata[:vimeo_id]&.to_s&.match(/(\d+)$/)&.values_at(1)&.first
       video.authors += authors if authors.present?
     end
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -8,7 +8,7 @@ class Video
   include Concerns::MarkdownRenderable
 
   attr_accessor :title, :ordinal, :free, :description_md, :short_description, :authors_notes_md,
-                :authors, :script_file, :root_path, :captions_file, :ref
+                :authors, :script_file, :root_path, :captions_file, :ref, :vimeo_id
 
   attr_markdown :description, source: :description_md, file: false
   attr_markdown :authors_notes, source: :authors_notes_md, file: false
@@ -40,7 +40,7 @@ class Video
   # Used for serialisation
   def attributes
     { title: nil, ordinal: nil, free: false, description: nil, short_description: nil, authors_notes: nil,
-      authors: [], transcript: nil, ref: nil, episode_type:, segment_type: }.stringify_keys
+      authors: [], transcript: nil, ref: nil, vimeo_id: nil, episode_type:, segment_type: }.stringify_keys
   end
 
   # Used for linting


### PR DESCRIPTION
Allows it to be blank, just the ID, or the vimeo URL.