### PR TITLE
WEB-7279: Visual bugs

### DIFF
--- a/app/server/views/content_modules/_table_of_contents.html.erb
+++ b/app/server/views/content_modules/_table_of_contents.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="toc-body">
       <div class="px-24">
-        <h2 class="module-title"><%= content_module.title %></h2>
+        <h2 class="module-title"><a href="/"><%= content_module.title %></a></h2>
         <p class="length"><%= content_module.lessons.size %> <%= 'lesson'.pluralize(content_module.lessons.size) %></p>
       </div>
       <% content_module.lessons.each do |lesson| %>

--- a/app/server/views/content_modules/_table_of_contents.html.erb
+++ b/app/server/views/content_modules/_table_of_contents.html.erb
@@ -20,7 +20,7 @@
             <% lesson.segments.each do |segment| %>
               <li class="<%= 'current-segment' if segment == current_segment %>">
                 <a href="<%= url(segment_path(lesson, segment)) %>">
-                  <span class="segment-ref"><%= segment.ref %> </span>
+                  <span class="segment-ref"><%= segment.ref %></span>.
                   <span class="segment-title"><%= segment.title %></span>
                 </a>
               </li>

--- a/app/server/views/content_modules/assessment.html.erb
+++ b/app/server/views/content_modules/assessment.html.erb
@@ -7,7 +7,7 @@
     </div>
 
     <div class="assessment-quiz">
-      <h1 class="segment-header"><%= segment.ref%>.<%= segment.title %></h1>
+      <h1 class="segment-header"><%= segment.ref%>. <%= segment.title %></h1>
       <% segment.questions.each do |question| %>
         <div class="quiz-container">
           <h3 class="written-content"><%= question.question %></h3>

--- a/app/server/views/content_modules/segment_transcript.html.erb
+++ b/app/server/views/content_modules/segment_transcript.html.erb
@@ -6,7 +6,7 @@
       <%= erb :'content_modules/_table_of_contents.html', locals: { content_module: content_module, current_segment: segment } %>
     </div>
     <div class="transcript-segment written-content">
-      <h1 class="segment-header"><%= segment.ref%>.<%= segment.title %></h1>
+      <h1 class="segment-header"><%= segment.ref%>. <%= segment.title %></h1>
       <div>
         <%= segment.transcript if segment.respond_to?(:transcript) %>
       </div>

--- a/app/server/views/content_modules/text.html.erb
+++ b/app/server/views/content_modules/text.html.erb
@@ -12,7 +12,7 @@
       <%= erb :'content_modules/_table_of_contents.html', locals: { content_module: content_module, current_segment: segment } %>
     </div>
     <div class="written-content">
-      <h1 class="segment-header"><%= segment.ref%>.<%= segment.title %></h1>
+      <h1 class="segment-header"><%= segment.ref%>. <%= segment.title %></h1>
       <div>
         <%= segment.body %>
       </div>

--- a/app/server/views/styles/components/modular.scss
+++ b/app/server/views/styles/components/modular.scss
@@ -295,6 +295,7 @@
           line-height: 1.5;
           padding-left: 12px;
           margin-bottom: 12px;
+          width: 95%;
         }
 
         ul.quiz-questions {
@@ -326,12 +327,14 @@
             .option-text {
               padding-inline: 24px;
               margin-bottom: 20px;
+              width: 95%;
             }
 
             .quiz-explanation {
               font-size: 0.875rem;
               line-height: 1.5;
               margin-left: 56px;
+              width: 90%;
 
               &.written-content {
                 p {

--- a/app/server/views/styles/components/modular.scss
+++ b/app/server/views/styles/components/modular.scss
@@ -217,6 +217,10 @@
                 font-size: 0.725rem;
                 padding: 6px;
                 height: 24px;
+
+                &:hover {
+                  background-color: $grey-thought-50;
+                }
               }
             }
           }

--- a/app/server/views/styles/components/navigation.scss
+++ b/app/server/views/styles/components/navigation.scss
@@ -2620,6 +2620,15 @@ footer#c-global-footer{
       .module-title {
         margin-bottom: 4px;
         font-size: 1.25rem;
+
+        a {
+          text-decoration: none;
+          color: $black-night;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
       }
 
       .length {

--- a/app/server/views/styles/components/written_content.scss
+++ b/app/server/views/styles/components/written_content.scss
@@ -105,7 +105,7 @@
      background-color: $white;
      border-radius: 16px;
 
-     p {
+     p:nth-of-type(1) {
       margin-top: unset;
      }
    }


### PR DESCRIPTION
- Long quiz questions should wrap before they go on a new line
- Hover class for slide button
- Make module title a link to home
- `ref. name` same everywhere
- Tidy a bit around noteblocks