### PR TITLE
WEB-7287: Transcript timestamp styling

### DIFF
--- a/app/server/views/styles/components/modular.scss
+++ b/app/server/views/styles/components/modular.scss
@@ -263,7 +263,7 @@
 
       ol, ul {
         .video-timestamp {
-          left: -92px;
+          left: -90px;
         }
       }
 

--- a/app/server/views/styles/components/modular.scss
+++ b/app/server/views/styles/components/modular.scss
@@ -257,15 +257,25 @@
     .transcript-segment {
 
       p, pre, ul, ol, h2, h3, h4 {
-        margin-left: 116px;
+        margin-left: 70px;
         position: relative;
       }
 
+      ol, ul {
+        .video-timestamp {
+          left: -92px;
+        }
+      }
+
       blockquote {
-        margin-left: 116px;
+        margin-left: 70px;
 
         p {
           margin: unset;
+
+          .video-timestamp {
+            left: -94px;
+          }
         }
       }
 
@@ -273,7 +283,7 @@
         display: flex;
         align-items: center;
         position: absolute;
-        left: -116px;
+        left: -70px;
         height: 24px;
         padding: 0 8px;
         font-size: 0.875rem;


### PR DESCRIPTION
- Updates the positioning of timestamps now they are shorter
- Fixes blockquotes and ul,ol and timestamps nonsense

<img width="461" alt="image" src="https://github.com/user-attachments/assets/34780e60-1bce-4e0b-b2af-a9373b98104c">
