### PR TITLE
WEB-7289: Fixing TOC numbering width

### DIFF
--- a/app/server/views/styles/components/modular.scss
+++ b/app/server/views/styles/components/modular.scss
@@ -175,6 +175,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            min-width: 56px;
             width: 56px;
             height: 56px;
             margin-right: 24px;


### PR DESCRIPTION
Old:
<img width="461" alt="image" src="https://github.com/user-attachments/assets/591d09d4-bef9-44b9-a5ae-7f7189389f5a">



New:

<img width="306" alt="image" src="https://github.com/user-attachments/assets/3594dceb-9552-4fe5-963a-75a12d4dd758">
