### PR TITLE
Make module circulation resilient to Slack/Alexandria failures

### DIFF
--- a/app/lib/api/alexandria/content_module_uploader.rb
+++ b/app/lib/api/alexandria/content_module_uploader.rb
@@ -10,6 +10,13 @@ module Api
 
       PUBLISH_URL = '/api/content_modules/publish'
 
+      # Seconds to wait when establishing the connection to Alexandria.
+      OPEN_TIMEOUT = 10
+      # Seconds to wait for Alexandria to accept the publish. Generous, because
+      # publishing a whole module can be slow, but bounded so a hung Alexandria
+      # fails (and is logged) instead of hanging CI indefinitely.
+      READ_TIMEOUT = 120
+
       def self.upload(content_module)
         new(content_module).upload
       end
@@ -19,13 +26,41 @@ module Api
       end
 
       def upload
-        conn.post do |req|
+        started_at = monotonic_now
+        log_upload_start
+        response = conn.post do |req|
           req.url api_uri
           req.body = payload
         end
+        log_upload_success(response, started_at)
+        response
+      rescue Faraday::Error => e
+        log_upload_failure(e, started_at)
+        raise
       end
 
       private
+
+      def log_upload_start
+        logger.info("Publishing content module '#{content_module.shortcode}' to Alexandria at #{api_uri} (#{payload.bytesize} bytes)")
+      end
+
+      def log_upload_success(response, started_at)
+        logger.info("Alexandria accepted content module '#{content_module.shortcode}' (HTTP #{response.status}) in #{elapsed_since(started_at)}s")
+      end
+
+      def log_upload_failure(error, started_at)
+        logger.error("Alexandria publish failed for content module '#{content_module.shortcode}' after #{elapsed_since(started_at)}s: #{error.class} (HTTP #{error.response_status || 'none'})")
+        logger.error("Alexandria response body: #{error.response_body}") if error.response_body.present?
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def elapsed_since(started_at)
+        (monotonic_now - started_at).round(1)
+      end
 
       def api_uri
         path = [
@@ -37,19 +72,26 @@ module Api
       end
 
       def conn
-        @conn ||= Faraday.new(headers: { 'Content-Type' => 'application/json' }) do |faraday|
-          faraday.response(:logger, logger) do |logger|
-            logger.filter(/(Token token=\\")(\w+)/, '\1[REMOVED]')
+        @conn ||= Faraday.new(
+          headers: { 'Content-Type' => 'application/json' },
+          request: { open_timeout: OPEN_TIMEOUT, timeout: READ_TIMEOUT }
+        ) do |faraday|
+          faraday.response(:logger, logger) do |filter|
+            filter.filter(/(Token token=\\")(\w+)/, '\1[REMOVED]')
           end
           faraday.response(:raise_error)
           faraday.adapter(Faraday.default_adapter)
           faraday.request(:authorization, 'Bearer', ALEXANDRIA_SERVICE_API_TOKEN)
+          # NOTE: faraday-retry's default `methods` excludes POST, so this does
+          # not actually retry the publish. Left as-is to avoid silently
+          # introducing (non-idempotent) publish retries; the timeouts above are
+          # what stop a hung Alexandria from blocking CI forever.
           faraday.request(:retry)
         end
       end
 
       def payload
-        { content_module: }.to_json
+        @payload ||= { content_module: }.to_json
       end
     end
   end

--- a/app/lib/image_provider/provider.rb
+++ b/app/lib/image_provider/provider.rb
@@ -15,14 +15,27 @@ module ImageProvider
     def process
       logger.info('Extracting images')
       extractor.extract
-      logger.info('Beginning image upload')
-      futures = extractor.images.map do |image|
+      logger.info("Beginning upload of #{extractor.images.count} image(s)")
+      Concurrent::Promises.zip(*upload_futures).wait
+      logger.info('Completed image upload')
+    end
+
+    def upload_futures
+      extractor.images.map do |image|
         Concurrent::Promises.future do
           image.upload
+        rescue StandardError => e
+          # Surface the failure: Concurrent::Promises#wait swallows rejected
+          # futures, so without this an image upload error (or hang) would
+          # otherwise vanish from the logs.
+          logger.error("Failed to upload image #{image_descriptor(image)}: #{e.class} #{e.message}")
+          raise
         end
       end
-      Concurrent::Promises.zip(*futures).wait
-      logger.info('Completed image upload')
+    end
+
+    def image_descriptor(image)
+      image.try(:key).presence || image.try(:local_url).presence || image.class.name
     end
 
     def representations_for_local_url(url)

--- a/app/lib/util/slack_notifiable.rb
+++ b/app/lib/util/slack_notifiable.rb
@@ -5,6 +5,17 @@ module Util
   module SlackNotifiable # rubocop:disable Metrics/ModuleLength
     extend ActiveSupport::Concern
 
+    included do
+      include Util::Logging
+    end
+
+    # Slack notifications are best-effort. A Slack problem - most notably webhook
+    # rate limiting (HTTP 429) when lots of modules circulate at once - must never
+    # fail or hang the publish/circulate itself. We therefore cap how long we'll
+    # wait on Slack, and log-then-swallow any delivery error.
+    SLACK_OPEN_TIMEOUT = 5
+    SLACK_READ_TIMEOUT = 5
+
     BOOK_SUCCESS_IMAGE_URL = 'https://cdn.kodeco.com/v3-resources/razebot/images/media-article-multi-platform.png'
     VIDEO_COURSE_SUCCESS_IMAGE_URL = 'https://cdn.kodeco.com/v3-resources/razebot/images/media-course-multi-platform.png'
     CONTENT_MODULE_SUCCESS_IMAGE_URL = 'https://cdn.kodeco.com/v3-resources/razebot/images/media-multi-multi-platform.png'
@@ -14,39 +25,45 @@ module Util
     CONTENT_MODULE_ROBLES_CONTEXT_IMAGE_URL = 'https://cdn.kodeco.com/v3-resources/razebot/images/media-path-multi-platform.png'
 
     def notify_book_success(book:)
-      return unless notifiable?
-
-      notifier.post(blocks: book_success_blocks(book:))
+      deliver('book publication success', blocks: book_success_blocks(book:))
     end
 
     def notify_book_failure(book:, details: nil)
-      return unless notifiable?
-
-      notifier.post(blocks: book_failure_blocks(book:, details: details || 'N/A'))
+      deliver('book publication failure', blocks: book_failure_blocks(book:, details: details || 'N/A'))
     end
 
     def notify_video_course_success(video_course:)
-      return unless notifiable?
-
-      notifier.post(blocks: video_course_success_blocks(video_course:))
+      deliver('video course upload success', blocks: video_course_success_blocks(video_course:))
     end
 
     def notify_video_course_failure(video_course:, details: nil)
-      return unless notifiable?
-
-      notifier.post(blocks: video_course_failure_blocks(video_course:, details: details || 'N/A'))
+      deliver('video course upload failure', blocks: video_course_failure_blocks(video_course:, details: details || 'N/A'))
     end
 
     def notify_content_module_success(content_module:)
-      return unless notifiable?
-
-      notifier.post(blocks: content_module_success_blocks(content_module:))
+      deliver('content module upload success', blocks: content_module_success_blocks(content_module:))
     end
 
     def notify_content_module_failure(content_module:, details: nil)
-      return unless notifiable?
+      deliver('content module upload failure', blocks: content_module_failure_blocks(content_module:, details: details || 'N/A'))
+    end
 
-      notifier.post(blocks: content_module_failure_blocks(content_module:, details: details || 'N/A'))
+    # Best-effort delivery of a Slack notification. Logs the outcome and never
+    # raises: a Slack failure (rate limit, timeout, network error) is logged and
+    # swallowed so it can't fail or mask the surrounding publish.
+    def deliver(description, blocks:)
+      unless notifiable?
+        logger.info("Skipping Slack notification (#{description}): SLACK_WEBHOOK_URL is not set")
+        return
+      end
+
+      logger.info("Sending Slack notification: #{description}")
+      notifier.post(blocks:)
+      logger.info("Sent Slack notification: #{description}")
+    rescue Slack::Notifier::APIError => e
+      logger.warn("Slack notification failed (#{description}); continuing without it. Slack API error: #{e.message}")
+    rescue StandardError => e
+      logger.warn("Slack notification failed (#{description}); continuing without it. #{e.class}: #{e.message}")
     end
 
     def notifiable?
@@ -54,7 +71,12 @@ module Util
     end
 
     def notifier
-      @notifier ||= Slack::Notifier.new(SLACK_WEBHOOK_URL, channel: SLACK_CHANNEL, username: SLACK_USERNAME)
+      @notifier ||= Slack::Notifier.new(
+        SLACK_WEBHOOK_URL,
+        channel: SLACK_CHANNEL,
+        username: SLACK_USERNAME,
+        http_options: { open_timeout: SLACK_OPEN_TIMEOUT, read_timeout: SLACK_READ_TIMEOUT }
+      )
     end
 
     def book_success_blocks(book:)


### PR DESCRIPTION
## Problem

Circulating a content module via CI (`docker://razeware/robles ... module circulate`) would either **hang for a long time** or **fail in a misleading way**. The trigger looked like Slack rate limiting, but there were three separate issues on the `module circulate` path, all of which made the job fragile and hard to diagnose.

## Root causes & fixes

**1. Slack notifications could fail/hang the publish (and mask success)**
`slack-notifier` raises `Slack::Notifier::APIError` on any non-2xx response, including a webhook **429 rate limit** (which is easy to hit when many module repos circulate at once and all POST the same webhook). The success notification raised, fell into `circulate_content_module`'s rescue, which fired a *second* Slack POST that raised again — masking a successful upload as a failure and exiting non-zero. The notifier also had no HTTP timeouts (Net::HTTP ~60s defaults).

- Slack delivery is now **best-effort**: every notification goes through a single `deliver` helper that logs the outcome and swallows rate-limit/timeout/network errors, so Slack can never fail, hang, or mask a publish.
- Added `open_timeout`/`read_timeout` to the notifier.
- Logs when it sends, succeeds, skips (no webhook), or fails (with the reason, e.g. `HTTP Code 429`).

**2. Alexandria publish had no timeouts and no logging**
The Faraday connection had no `timeout`/`open_timeout`, so a slow/unresponsive Alexandria blocked CI indefinitely — and there was nothing in the log to tell you what it was waiting on.

- Added `open_timeout: 10s` and `timeout: 120s` (generous for a real publish, bounded so a hang fails-and-logs instead of blocking forever).
- Added start/success/failure logging: URL + payload size, HTTP status, duration, and the response body on error.
- Documented that `faraday.request(:retry)` is a no-op here (faraday-retry's default `methods` excludes POST), so no non-idempotent publish retries were silently introduced.

**3. Image upload failures were silently swallowed**
`Concurrent::Promises.zip(*futures).wait` swallows rejected futures, so a failed/hung S3 image upload vanished from the logs.

- Logs the image count and each per-image failure. Behaviour is otherwise unchanged — a failing image still doesn't fail the run, it's just visible now.

## Net effect
The CI log now pinpoints where circulation is stuck: `Beginning upload of N image(s)` without a `Completed`, or `Publishing content module … to Alexandria` followed — within 120s, not never — by an `accepted`/`failed` line with status, duration, and body.

## Testing
- `rubocop` clean on all changed files.
- App boots and both classes autoload under Zeitwerk against the upgraded gems.
- Exercised the new logging end-to-end: Slack skip + 429 paths; Alexandria 200 (success log) and 500 (failure log with body + re-raise); confirmed Faraday timeout/error helpers and `retry_block` signature.

## Follow-ups (not in this PR)
- `book_uploader.rb` and `betamax/video_course_uploader.rb` share the identical no-timeout pattern — happy to apply the same fix.
- The swallowed image errors are a latent bug; kept pass/fail behaviour to avoid turning green runs red mid-debug. One-line switch (`.wait` → `.value!`) makes it fail loudly if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)