### PR TITLE
Stop animated-GIF resizing from hanging module circulation

### DIFF
--- a/app/lib/image_provider/provider.rb
+++ b/app/lib/image_provider/provider.rb
@@ -15,14 +15,25 @@ module ImageProvider
     def process
       logger.info('Extracting images')
       extractor.extract
-      logger.info("Beginning upload of #{extractor.images.count} image(s)")
-      Concurrent::Promises.zip(*upload_futures).wait
+      logger.info("Beginning upload of #{extractor.images.count} image(s), up to #{upload_concurrency} at a time")
+      pool = Concurrent::FixedThreadPool.new(upload_concurrency)
+      Concurrent::Promises.zip(*upload_futures(pool)).wait
+      pool.shutdown
+      pool.wait_for_termination
       logger.info('Completed image upload')
     end
 
-    def upload_futures
+    # Resizing images (notably animated GIFs) shells out to ImageMagick, which
+    # is CPU- and memory-hungry. Running every image at once on a small CI
+    # runner exhausts resources and can grind the whole step to a halt, so we
+    # cap how many upload/resize jobs run concurrently.
+    def upload_concurrency
+      @upload_concurrency ||= [ENV.fetch('ROBLES_IMAGE_UPLOAD_CONCURRENCY', Concurrent.processor_count).to_i, 1].max
+    end
+
+    def upload_futures(pool)
       extractor.images.map do |image|
-        Concurrent::Promises.future do
+        Concurrent::Promises.future_on(pool) do
           image.upload
         rescue StandardError => e
           # Surface the failure: Concurrent::Promises#wait swallows rejected

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -48,18 +48,46 @@ class Image
   def upload
     representations.each do |representation|
       if representation.uploaded?
-        logger.info "Skipping #{local_url}"
+        logger.info "Skipping #{representation.width} variant for #{local_url} (already uploaded)"
         next
       end
-      logger.info "Generating #{representation.width} variant for #{local_url}"
-      representation.generate
-      logger.info "Uploading #{representation.width} variant for #{local_url}"
-      representation.upload
+      generate_variant(representation)
+      upload_variant(representation)
     end
   end
 
   # Used for linting
   def validation_name
     local_url
+  end
+
+  private
+
+  def generate_variant(representation)
+    logger.info "Generating #{representation.width} variant for #{local_url} (source #{source_size})"
+    started = monotonic_now
+    representation.generate
+    logger.info "Generated #{representation.width} variant for #{local_url} in #{elapsed_since(started)}s"
+  end
+
+  def upload_variant(representation)
+    logger.info "Uploading #{representation.width} variant for #{local_url}"
+    started = monotonic_now
+    representation.upload
+    logger.info "Uploaded #{representation.width} variant for #{local_url} in #{elapsed_since(started)}s"
+  end
+
+  def source_size
+    "#{(File.size(local_url) / 1024.0 / 1024.0).round(1)}MB"
+  rescue SystemCallError
+    'unknown size'
+  end
+
+  def monotonic_now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def elapsed_since(started)
+    (monotonic_now - started).round(1)
   end
 end

--- a/config/initialisers/mini_magick.rb
+++ b/config/initialisers/mini_magick.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Bound how long any single ImageMagick command may run. Resizing large
+# animated GIFs can otherwise take a very long time (or effectively hang),
+# which would block module circulation in CI indefinitely. When the limit is
+# exceeded MiniMagick raises, which is logged and surfaced by the image
+# uploader rather than hanging the job.
+MiniMagick.configure do |config|
+  config.timeout = ENV.fetch('ROBLES_MINI_MAGICK_TIMEOUT', 120).to_i
+end


### PR DESCRIPTION
Follow-up to #327. With Slack and Alexandria ruled out, a staging `module circulate` run (built from #327, so it has the new image logging) showed where it actually hangs.

## Evidence from the CI log
```
Beginning upload of 17 image(s)
...
Generating small variant for …/grayscale-filter.gif
Generating small variant for …/camera-capture.gif
Generating small variant for …/full-edit-functionality.gif
Generating small variant for …/verify-persistence.gif
```
Six **animated GIFs** each log `Generating small variant …` — and **none** is ever followed by the matching `Uploading …` line, there's no `Completed image upload`, no error, then ~50s of silence before the step ends. Since `Completed image upload` is logged unconditionally once the uploads finish, its absence means the run is blocked inside `representation.generate` — ImageMagick resizing animated GIFs — and never reaches Alexandria.

## Root cause
`ImageProvider::Provider` mapped every image onto the **unbounded** global thread pool, so all the heavy GIF resizes (`MiniMagick` → ImageMagick `convert`, which coalesces every frame into memory) ran at once. On a small CI runner that exhausts CPU/memory and the resizes stall *together* — which is exactly the pattern in the log (all six stuck simultaneously, not one bad file).

## Changes
- **Bound upload/resize concurrency** with a `FixedThreadPool` (defaults to `Concurrent.processor_count`, override with `ROBLES_IMAGE_UPLOAD_CONCURRENCY`) so heavy ImageMagick jobs no longer all run at once.
- **MiniMagick command timeout** (`config/initialisers/mini_magick.rb`, default 120s, override with `ROBLES_MINI_MAGICK_TIMEOUT`) so no single resize can hang the job forever — on timeout it raises and is logged by the image uploader.
- **Per-variant timing + source-size logging** in `Image#upload`: `Generating … (source 14.2MB)` → `Generated … in 38.5s`, plus `Uploading`/`Uploaded`. The next run will name the offending image and its duration outright.

## Testing
- `rubocop` clean; app boots and autoloads against current `development` + the new initializer (`MiniMagick.timeout` = 120).
- Verified the bounded pool caps concurrency (peak == cap) while still completing, and that a failing image is logged but swallowed (behaviour unchanged).
- Verified the new `Image#upload` logging, including the `unknown size` fallback when the source file is missing.

## Notes
- Concurrency default is conservative (CPU count) and tunable per-repo via env without a code change. If GIF resizes are still slow one-at-a-time, the timing logs will now show it and we can look at resizing animated GIFs more cheaply (e.g. coalesce/limit frames).
- Image-upload failures are still logged-but-swallowed (a failing image doesn't fail the publish). Same latent behaviour flagged in #327; happy to switch to fail-loud (`.wait` → `.value!`) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)