### PR TITLE
Upload GIFs as-is instead of resizing them

### DIFF
--- a/app/lib/renderer/rw_markdown_renderer.rb
+++ b/app/lib/renderer/rw_markdown_renderer.rb
@@ -29,7 +29,10 @@ module Renderer
           out(svg_content(node.url))
         else
           out('    <img src="', src(node.url), '" alt="', title, '" title="', title, '">')
-          out('    <source srcset="', srcset(node.url), '">')
+          image_srcset = srcset(node.url)
+          # GIFs (and any image without generated variants) only have the
+          # original, so skip the empty <source> rather than emit a broken one.
+          out('    <source srcset="', image_srcset, '">') if image_srcset.present?
         end
         out('  </picture>')
         out('  <figcaption>', title, '</figcaption>')

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -5,11 +5,17 @@ class Image
   include ActiveModel::Model
   include Util::Logging
 
+  # Formats we never resize. Resizing animated GIFs (e.g. screen recordings)
+  # is hugely memory-hungry and slow in CI, so we upload the original only and
+  # the renderer references it for every size instead of generated variants.
+  NON_RESIZABLE_EXTENSIONS = %w[.gif].freeze
+
   attr_accessor :local_url, :representations, :uploaded_image_root_path
 
   def self.with_representations(attributes = {}, variants: nil, representation_attributes: {})
     variants ||= ImageRepresentation::DEFAULT_WIDTHS.keys
     new(attributes).tap do |image|
+      variants = %i[original] unless image.resizable?
       image.representations = variants.map do |width|
         ImageRepresentation.new(representation_attributes.merge(width:, image:))
       end
@@ -35,6 +41,10 @@ class Image
 
   def extension
     @extension ||= Pathname.new(local_url).extname
+  end
+
+  def resizable?
+    NON_RESIZABLE_EXTENSIONS.exclude?(extension.downcase)
   end
 
   def source_filename


### PR DESCRIPTION
Follow-up to #329. With the logging and memory limits in place, a staging `module circulate` finally **completed** (published to Alexandria, HTTP 201) — but the GIF resize step took **~6 minutes** (`15:29:25` → `15:35:15` in the logs) for one module. Animated-GIF thumbnails aren't worth that, so per the product decision we stop resizing GIFs and just upload the originals.

## Change
- **`Image` builds only the `:original` representation for non-resizable formats (`.gif`)** — no small/medium/large variants are generated or uploaded, and ImageMagick is never invoked for GIFs at all. PNGs/JPEGs are unchanged (all variants still generated).
- **The markdown renderer omits the `<source srcset>` element when an image has no generated variants**, so a GIF is referenced via `<img src=".../original.gif">` for every size instead of pointing at variant URLs that were never produced.

Net effect: GIFs upload once, instantly, with no resizing — and the rendered HTML references the original rather than broken variant links.

## Why this is safe
- Attachments (cover art, banners, twitter cards) use explicit variant lists and are always PNG/JPG artwork, never GIFs — they're unaffected.
- `Renderer::ImageAttributes` is included only by `RWMarkdownRenderer`, and that's the only place that emits variant `<source>`s, so the renderer change is complete.
- The ImageMagick resource limits + wall-clock timeout from #329 remain as a safety net for everything still resized.

## Testing
- `rubocop` clean; app boots.
- Model: `.gif`/`.GIF` → `[:original]` only; `.png` → `[:small, :medium, :large, :original]`; even a GIF attachment requesting `%i[original w750 w225 w90]` collapses to `[:original]`.
- End-to-end render:
  - GIF → `<picture><img src=".../original.gif"></picture>` (no `<source>`).
  - PNG → `<img>` + `<source srcset="...w150... w300... w700...">` (unchanged).
- Confirmed `original` generation invokes no ImageMagick (it just uploads the source file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)